### PR TITLE
End-developers must call import.meta.url

### DIFF
--- a/packages/blueprints/src/blueprints/get-absolute-path.js
+++ b/packages/blueprints/src/blueprints/get-absolute-path.js
@@ -1,8 +1,0 @@
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url);
-
-export function getAbsolutePath() {
-  return dirname(__filename);
-}

--- a/packages/blueprints/src/blueprints/get-file-path.js
+++ b/packages/blueprints/src/blueprints/get-file-path.js
@@ -1,0 +1,9 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function getFilePath(fileURL) {
+  const __filename = fileURLToPath(fileURL);
+  const __dirname = dirname(__filename);
+
+  return __dirname;
+}

--- a/packages/blueprints/src/index.js
+++ b/packages/blueprints/src/index.js
@@ -1,3 +1,3 @@
 export * from './blueprints/decide-version.js';
-export * from './blueprints/get-absolute-path.js';
+export * from './blueprints/get-file-path.js';
 export * from './blueprints/process-template.js';

--- a/packages/blueprints/tests/blueprints/get-absolute-path/base-case.test.js
+++ b/packages/blueprints/tests/blueprints/get-absolute-path/base-case.test.js
@@ -1,9 +1,0 @@
-import { assert, test } from '@codemod-utils/tests';
-
-import { getAbsolutePath } from '../../../src/index.js';
-
-test('blueprints | get-absolute-path > base case', function () {
-  const __dirname = getAbsolutePath();
-
-  assert.strictEqual(__dirname.endsWith('src/blueprints'), true);
-});

--- a/packages/blueprints/tests/blueprints/get-file-path/base-case.test.js
+++ b/packages/blueprints/tests/blueprints/get-file-path/base-case.test.js
@@ -1,0 +1,10 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { getFilePath } from '../../../src/index.js';
+
+test('blueprints | get-file-path > base case', function () {
+  const fileURL = import.meta.url;
+  const filePath = getFilePath(fileURL);
+
+  assert.strictEqual(filePath.endsWith('tests/blueprints/get-file-path'), true);
+});


### PR DESCRIPTION
## Background

End-developers are expected to use `getAbsolutePath()`, to (not have to) know where their `blueprints` directory will be, once the codemod is installed on their end-user's machine.

Currently, `getAbsolutePath()` calls `import.meta.url`, which results in an incorrect return value:

```ts
/* In some codemod project, e.g. ember-codemod-v1-to-v2 */
import { getAbsolutePath } from '@codemod-utils/blueprints';

console.log(getAbsolutePath()); /* /ember-codemod-v1-to-v2/node_modules/@codemod-utils/blueprints/src/blueprints */
```

We expect to see `/ember-codemod-v1-to-v2/src/blueprints` instead.


## What changed?

I renamed the function to `getFilePath()` and updated its API so that `getFilePath` does not call `import.meta.url`. End-developers may instead write:

```ts
/* src/utils/blueprints/blueprints-root.js */
import { join } from 'node:path';

import { getFilePath } from '@codemod-utils/blueprints';

const fileURL = import.meta.url;
const srcDirectory = join(getFilePath(fileURL), '../..');

export const blueprintsRoot = join(srcDirectory, 'blueprints'); /* There exists src/blueprints */
```
