### PR TITLE
Reverted API (copyFiles, moveFiles)

### DIFF
--- a/.changeset/orange-actors-flash.md
+++ b/.changeset/orange-actors-flash.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/files": patch
+---
+
+Reverted API (copyFiles, moveFiles)

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -26,14 +26,17 @@ Copy files from one directory to another.
 In [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), we want to copy some files from the project root to the addon package.
 
 ```js
-import { copyFiles } from '@codemod-utils/files';
+import { copyFiles, mapFilePaths } from '@codemod-utils/files';
 
-const filePaths = ['LICENSE.md', 'README.md'];
+const filePaths = [/* ... */];
 
-copyFiles(filePaths, {
+const filePathMap = mapFilePaths(filePaths, {
   from: '',
-  projectRoot: '__projectRoot__',
   to: '__addonLocation__',
+});
+
+copyFiles(filePathMap, {
+  projectRoot: '__projectRoot__',
 });
 ```
 
@@ -129,6 +132,11 @@ const filePaths = findFiles(unionize(files), {
 </details>
 
 
+### mapFilePaths
+
+Create a mapping of file paths, which can be passed to [`createFiles`](#createfiles) or [`moveFiles`](#movefiles). 
+
+
 ### moveFiles
 
 Move files from one directory to another.
@@ -140,19 +148,17 @@ Move files from one directory to another.
 In [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), we want to move some files from the project root to the test-app package.
 
 ```js
-import { copyFiles } from '@codemod-utils/files';
+import { mapFilePaths, moveFiles } from '@codemod-utils/files';
 
-const files = [
-  '.ember-cli',
-  '.watchmanconfig',
-  'ember-cli-build.js',
-  'testem.js',
-];
+const filePaths = [/* ... */];
 
-copyFiles(filePaths, {
+const filePathMap = mapFilePaths(filePaths, {
   from: '',
-  projectRoot: '__projectRoot__',
   to: '__testAppLocation__',
+});
+
+moveFiles(filePathMap, {
+  projectRoot: '__projectRoot__',
 });
 ```
 

--- a/packages/files/src/files/copy-files.js
+++ b/packages/files/src/files/copy-files.js
@@ -2,14 +2,11 @@ import { copyFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { createDirectory } from './create-directory.js';
-import { renamePathByDirectory } from './rename-path-by-directory.js';
 
-export function copyFiles(filePaths, options) {
-  const { from, projectRoot, to } = options;
+export function copyFiles(filePathMap, options) {
+  const { projectRoot } = options;
 
-  filePaths.forEach((oldFilePath) => {
-    const newFilePath = renamePathByDirectory(oldFilePath, { from, to });
-
+  filePathMap.forEach((newFilePath, oldFilePath) => {
     const source = join(projectRoot, oldFilePath);
     const destination = join(projectRoot, newFilePath);
 

--- a/packages/files/src/files/map-file-paths.js
+++ b/packages/files/src/files/map-file-paths.js
@@ -1,0 +1,11 @@
+import { renamePathByDirectory } from './rename-path-by-directory.js';
+
+export function mapFilePaths(filePaths, { from, to }) {
+  return new Map(
+    filePaths.map((oldFilePath) => {
+      const newFilePath = renamePathByDirectory(oldFilePath, { from, to });
+
+      return [oldFilePath, newFilePath];
+    }),
+  );
+}

--- a/packages/files/src/files/move-files.js
+++ b/packages/files/src/files/move-files.js
@@ -3,14 +3,11 @@ import { join } from 'node:path';
 
 import { createDirectory } from './create-directory.js';
 import { removeDirectoryIfEmpty } from './remove-directory-if-empty.js';
-import { renamePathByDirectory } from './rename-path-by-directory.js';
 
-export function moveFiles(filePaths, options) {
-  const { from, projectRoot, to } = options;
+export function moveFiles(filePathMap, options) {
+  const { projectRoot } = options;
 
-  filePaths.forEach((oldFilePath) => {
-    const newFilePath = renamePathByDirectory(oldFilePath, { from, to });
-
+  filePathMap.forEach((newFilePath, oldFilePath) => {
     const source = join(projectRoot, oldFilePath);
     const destination = join(projectRoot, newFilePath);
 

--- a/packages/files/src/index.js
+++ b/packages/files/src/index.js
@@ -2,6 +2,7 @@ export * from './files/copy-files.js';
 export * from './files/create-directory.js';
 export * from './files/create-files.js';
 export * from './files/find-files.js';
+export * from './files/map-file-paths.js';
 export * from './files/move-files.js';
 export * from './files/remove-directory-if-empty.js';
 export * from './files/remove-files.js';

--- a/packages/files/tests/files/copy-files/base-case.test.js
+++ b/packages/files/tests/files/copy-files/base-case.test.js
@@ -23,12 +23,13 @@ test('files | copy-files > base case', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = ['.eslintrc.js', 'package.json'];
+  const filePathMap = new Map([
+    ['.eslintrc.js', 'ember-container-query/.eslintrc.js'],
+    ['package.json', 'ember-container-query/package.json'],
+  ]);
 
-  copyFiles(filePaths, {
-    from: '',
+  copyFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: 'ember-container-query',
   });
 
   assertFixture(outputProject, codemodOptions);

--- a/packages/files/tests/files/copy-files/edge-case-filePathMap-is-empty.test.js
+++ b/packages/files/tests/files/copy-files/edge-case-filePathMap-is-empty.test.js
@@ -3,7 +3,7 @@ import { assertFixture, loadFixture, test } from '@codemod-utils/tests';
 import { copyFiles } from '../../../src/index.js';
 import { codemodOptions, options } from '../../shared-test-setups/index.js';
 
-test('files | copy-files > edge case (filePaths is empty)', function () {
+test('files | copy-files > edge case (filePathMap is empty)', function () {
   const inputProject = {
     '.editorconfig': 'some code for .editorconfig',
     '.eslintrc.js': 'some code for .eslintrc.js',
@@ -18,12 +18,10 @@ test('files | copy-files > edge case (filePaths is empty)', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = [];
+  const filePathMap = new Map();
 
-  copyFiles(filePaths, {
-    from: '',
+  copyFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: 'ember-container-query',
   });
 
   assertFixture(outputProject, codemodOptions);

--- a/packages/files/tests/files/copy-files/edge-case-from-and-to-are-sibling-directories.test.js
+++ b/packages/files/tests/files/copy-files/edge-case-from-and-to-are-sibling-directories.test.js
@@ -26,12 +26,10 @@ test('files | copy-files > edge case (from and to are sibling directories)', fun
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = ['app/styles/app.css'];
+  const filePathMap = new Map([['app/styles/app.css', 'app/assets/app.css']]);
 
-  copyFiles(filePaths, {
-    from: 'app/styles',
+  copyFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: 'app/assets',
   });
 
   assertFixture(outputProject, codemodOptions);

--- a/packages/files/tests/files/copy-files/edge-case-from-and-to-are-the-same.test.js
+++ b/packages/files/tests/files/copy-files/edge-case-from-and-to-are-the-same.test.js
@@ -18,12 +18,13 @@ test('files | copy-files > edge case (from and to are the same)', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = ['.eslintrc.js', 'package.json'];
+  const filePathMap = new Map([
+    ['.eslintrc.js', '.eslintrc.js'],
+    ['package.json', 'package.json'],
+  ]);
 
-  copyFiles(filePaths, {
-    from: '',
+  copyFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: '',
   });
 
   assertFixture(outputProject, codemodOptions);

--- a/packages/files/tests/files/map-file-paths/base-case.test.js
+++ b/packages/files/tests/files/map-file-paths/base-case.test.js
@@ -1,0 +1,23 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { mapFilePaths } from '../../../src/index.js';
+
+test('files | map-file-paths > base case', function () {
+  const filePaths = ['addon/some-folder/some-file.ts', 'addon/.gitkeep'];
+
+  const filePathMap = mapFilePaths(filePaths, {
+    from: 'addon',
+    to: 'new-location/src',
+  });
+
+  assert.deepStrictEqual(
+    filePathMap,
+    new Map([
+      [
+        'addon/some-folder/some-file.ts',
+        'new-location/src/some-folder/some-file.ts',
+      ],
+      ['addon/.gitkeep', 'new-location/src/.gitkeep'],
+    ]),
+  );
+});

--- a/packages/files/tests/files/map-file-paths/edge-case-no-match.test.js
+++ b/packages/files/tests/files/map-file-paths/edge-case-no-match.test.js
@@ -1,0 +1,22 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { mapFilePaths } from '../../../src/index.js';
+
+test('files | map-file-paths > edge case (no match)', function () {
+  const filePaths = ['.addon/index.js', 'addon', 'addon.js', 'app/index.js'];
+
+  const filePathMap = mapFilePaths(filePaths, {
+    from: 'addon',
+    to: 'new-location/src',
+  });
+
+  assert.deepStrictEqual(
+    filePathMap,
+    new Map([
+      ['.addon/index.js', '.addon/index.js'],
+      ['addon', 'addon'],
+      ['addon.js', 'addon.js'],
+      ['app/index.js', 'app/index.js'],
+    ]),
+  );
+});

--- a/packages/files/tests/files/move-files/base-case.test.js
+++ b/packages/files/tests/files/move-files/base-case.test.js
@@ -38,15 +38,19 @@ test('files | move-files > base case', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = [
-    'addon/components/container-query.hbs',
-    'addon/components/container-query.ts',
-  ];
+  const filePathMap = new Map([
+    [
+      'addon/components/container-query.hbs',
+      'ember-container-query/src/components/container-query.hbs',
+    ],
+    [
+      'addon/components/container-query.ts',
+      'ember-container-query/src/components/container-query.ts',
+    ],
+  ]);
 
-  moveFiles(filePaths, {
-    from: 'addon',
+  moveFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: 'ember-container-query/src',
   });
 
   assertFixture(outputProject, codemodOptions);

--- a/packages/files/tests/files/move-files/edge-case-filePathMap-is-empty.test.js
+++ b/packages/files/tests/files/move-files/edge-case-filePathMap-is-empty.test.js
@@ -3,7 +3,7 @@ import { assertFixture, loadFixture, test } from '@codemod-utils/tests';
 import { moveFiles } from '../../../src/index.js';
 import { codemodOptions, options } from '../../shared-test-setups/index.js';
 
-test('files | move-files > edge case (filePaths is empty)', function () {
+test('files | move-files > edge case (filePathMap is empty)', function () {
   const inputProject = {
     addon: {
       components: {
@@ -36,12 +36,10 @@ test('files | move-files > edge case (filePaths is empty)', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = [];
+  const filePathMap = new Map();
 
-  moveFiles(filePaths, {
-    from: 'addon',
+  moveFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: 'ember-container-query/src',
   });
 
   assertFixture(outputProject, codemodOptions);

--- a/packages/files/tests/files/move-files/edge-case-from-and-to-are-sibling-directories.test.js
+++ b/packages/files/tests/files/move-files/edge-case-from-and-to-are-sibling-directories.test.js
@@ -23,12 +23,10 @@ test('files | move-files > edge case (from and to are sibling directories)', fun
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = ['app/styles/app.css'];
+  const filePathMap = new Map([['app/styles/app.css', 'app/assets/app.css']]);
 
-  moveFiles(filePaths, {
-    from: 'app/styles',
+  moveFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: 'app/assets',
   });
 
   assertFixture(outputProject, codemodOptions);

--- a/packages/files/tests/files/move-files/edge-case-from-and-to-are-the-same.test.js
+++ b/packages/files/tests/files/move-files/edge-case-from-and-to-are-the-same.test.js
@@ -36,15 +36,19 @@ test('files | move-files > edge case (from and to are the same)', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = [
-    'addon/components/container-query.hbs',
-    'addon/components/container-query.ts',
-  ];
+  const filePathMap = new Map([
+    [
+      'addon/components/container-query.hbs',
+      'addon/components/container-query.hbs',
+    ],
+    [
+      'addon/components/container-query.ts',
+      'addon/components/container-query.ts',
+    ],
+  ]);
 
-  moveFiles(filePaths, {
-    from: 'addon',
+  moveFiles(filePathMap, {
     projectRoot: options.projectRoot,
-    to: 'addon',
   });
 
   assertFixture(outputProject, codemodOptions);


### PR DESCRIPTION
## Description

I forget that `ember-codemod-pod-to-octane` needs to use `renamePathByFile` to rename paths.

In `@codemod-utils/files@0.3.0`, `copyFiles` and `moveFiles` are tightly coupled to `renamePathByDirectory` so it's not possible to call `moveFiles` in `ember-codemod-pod-to-octane` without drastically altering the migration approach.
