### PR TITLE
Tagged 0.4.0

### DIFF
--- a/.changeset/curvy-vans-lie.md
+++ b/.changeset/curvy-vans-lie.md
@@ -1,6 +1,0 @@
----
-"@codemod-utils/json": minor
-"@codemod-utils/tests": patch
----
-
-Introduced TypeScript

--- a/.changeset/dull-drinks-float.md
+++ b/.changeset/dull-drinks-float.md
@@ -1,6 +1,0 @@
----
-"@codemod-utils/ast": minor
-"@codemod-utils/files": patch
----
-
-Introduced TypeScript

--- a/.changeset/smart-paws-fold.md
+++ b/.changeset/smart-paws-fold.md
@@ -1,7 +1,0 @@
----
-"@codemod-utils/files": minor
-"@codemod-utils/tests": patch
-"@codemod-utils/json": patch
----
-
-Introduced TypeScript

--- a/.changeset/sour-pumpkins-sniff.md
+++ b/.changeset/sour-pumpkins-sniff.md
@@ -1,5 +1,0 @@
----
-"@codemod-utils/blueprints": minor
----
-
-Introduced TypeScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-root",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "description": "Workspace root for @codemod-utils",
   "repository": {

--- a/packages/ast/CHANGELOG.md
+++ b/packages/ast/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for @codemod-utils/ast
 
+## 0.2.0
+
+### Minor Changes
+
+- [#25](https://github.com/ijlee2/codemod-utils/pull/25) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-utils/ast",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Utilities for handling abstract syntax tree",
   "keywords": [
     "codemod",

--- a/packages/blueprints/CHANGELOG.md
+++ b/packages/blueprints/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for @codemod-utils/blueprints
 
+## 0.2.0
+
+### Minor Changes
+
+- [#22](https://github.com/ijlee2/codemod-utils/pull/22) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/blueprints/package.json
+++ b/packages/blueprints/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-utils/blueprints",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Utilities for blueprints",
   "keywords": [
     "codemod",

--- a/packages/files/CHANGELOG.md
+++ b/packages/files/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for @codemod-utils/files
 
+## 0.4.0
+
+### Minor Changes
+
+- [#21](https://github.com/ijlee2/codemod-utils/pull/21) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+
+### Patch Changes
+
+- [#25](https://github.com/ijlee2/codemod-utils/pull/25) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-utils/files",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Utilities for handling files",
   "keywords": [
     "codemod",

--- a/packages/json/CHANGELOG.md
+++ b/packages/json/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for @codemod-utils/json
 
+## 0.3.0
+
+### Minor Changes
+
+- [#20](https://github.com/ijlee2/codemod-utils/pull/20) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+
+### Patch Changes
+
+- [#21](https://github.com/ijlee2/codemod-utils/pull/21) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-utils/json",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Utilities for handling JSON",
   "keywords": [
     "codemod",

--- a/packages/tests/CHANGELOG.md
+++ b/packages/tests/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for @codemod-utils/tests
 
+## 0.2.1
+
+### Patch Changes
+
+- [#20](https://github.com/ijlee2/codemod-utils/pull/20) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+- [#21](https://github.com/ijlee2/codemod-utils/pull/21) Introduced TypeScript ([@ijlee2](https://github.com/ijlee2))
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-utils/tests",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Utilities for tests",
   "keywords": [
     "codemod",


### PR DESCRIPTION
In tag `0.4.0`, all `@codemod-utils` packages will ship types.