### PR TITLE
Reexported types and rebuilt dist

### DIFF
--- a/.changeset/lovely-lizards-lick.md
+++ b/.changeset/lovely-lizards-lick.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/files": patch
+---
+
+Reexported types and rebuilt dist

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -8,3 +8,4 @@ export * from './files/remove-directory-if-empty.js';
 export * from './files/remove-files.js';
 export * from './files/rename-path-by-directory.js';
 export * from './files/rename-path-by-file.js';
+export * from './types/index.js';


### PR DESCRIPTION
## Description

After installing `@codemod-utils/files@0.4.0` in `ember-codemod-pod-to-octane`, I realized that an empty declaration file had been published for `files/rename-path-by-file.js`.

<img width="900" alt="" src="https://github.com/ijlee2/codemod-utils/assets/16869656/0d259058-1b97-4cd6-8986-a204b129dbf1">

As a result, TypeScript threw the error `Module '"@codemod-utils/files"' has no exported member 'renamePathByFile'.`, though the method is visible in the class file.

<img width="900" alt="" src="https://github.com/ijlee2/codemod-utils/assets/16869656/66c174b8-497f-40be-9cfb-3f2630a70ae9">

I suspect that I might have published the wrong `dist` in `v0.4.0`. I'll publish a patch version to test the theory.
