### PR TITLE
Export parseFilePath

### DIFF
--- a/.changeset/tricky-countries-deliver.md
+++ b/.changeset/tricky-countries-deliver.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/files": minor
+---
+
+Exported parseFilePath

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -165,6 +165,31 @@ moveFiles(filePathMap, {
 </details>
 
 
+### parseFilePath
+
+Parse a file path, just like you can with `parse` from `node:path`. `parseFilePath` can handle file extensions with more than one `.` (e.g. `.d.ts`, `.css.d.ts`).
+
+<details>
+
+<summary>Example</summary>
+
+```js
+import { parseFilePath } from '@codemod-utils/files';
+
+const filePath = 'src/components/navigation-menu.d.ts';
+const { base, dir, ext, name } = parseFilePath(filePath);
+
+/*
+  base = 'navigation-menu.d.ts'
+  dir = 'src/components'
+  ext = '.d.ts'
+  name = 'navigation-menu'
+*/
+```
+
+</details>
+
+
 ### removeDirectoryIfEmpty
 
 Ensure that, after deleting a file, the directories in the file path are removed if empty.

--- a/packages/files/src/files/parse-file-path.ts
+++ b/packages/files/src/files/parse-file-path.ts
@@ -1,0 +1,22 @@
+import { parse } from 'node:path';
+
+import type { FilePath, ParsedPath } from '../types/index.js';
+
+export function parseFilePath(filePath: FilePath): ParsedPath {
+  // eslint-disable-next-line prefer-const
+  let { base, dir, ext, name } = parse(filePath);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { ext: extPrefix, name: fileName } = parse(name);
+
+    if (extPrefix === '') {
+      break;
+    }
+
+    ext = `${extPrefix}${ext}`;
+    name = fileName;
+  }
+
+  return { base, dir, ext, name };
+}

--- a/packages/files/src/files/rename-path-by-file.ts
+++ b/packages/files/src/files/rename-path-by-file.ts
@@ -1,6 +1,5 @@
-import { parse } from 'node:path';
-
 import type { FilePath } from '../types/index.js';
+import { parseFilePath } from './parse-file-path.js';
 
 type Options = {
   find: {
@@ -10,37 +9,12 @@ type Options = {
   replace: (key: string) => string;
 };
 
-type ParsedPath = {
-  dir: string;
-  ext: string;
-  name: string;
-};
-
-function parsePath(filePath: FilePath): ParsedPath {
-  // eslint-disable-next-line prefer-const
-  let { dir, ext, name } = parse(filePath);
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const { ext: extPrefix, name: fileName } = parse(name);
-
-    if (extPrefix === '') {
-      break;
-    }
-
-    ext = `${extPrefix}${ext}`;
-    name = fileName;
-  }
-
-  return { dir, ext, name };
-}
-
 export function renamePathByFile(
   filePath: FilePath,
   options: Options,
 ): FilePath {
+  const { dir, ext, name } = parseFilePath(filePath);
   const { find, replace } = options;
-  const { dir, ext, name } = parsePath(filePath);
 
   if (!dir.startsWith(find.directory)) {
     throw new RangeError(

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -4,6 +4,7 @@ export * from './files/create-files.js';
 export * from './files/find-files.js';
 export * from './files/map-file-paths.js';
 export * from './files/move-files.js';
+export * from './files/parse-file-path.js';
 export * from './files/remove-directory-if-empty.js';
 export * from './files/remove-files.js';
 export * from './files/rename-path-by-directory.js';

--- a/packages/files/src/types/index.ts
+++ b/packages/files/src/types/index.ts
@@ -11,4 +11,18 @@ type Options = {
   projectRoot: string;
 };
 
-export type { FileContent, FileMap, FilePath, FilePathMap, Options };
+type ParsedPath = {
+  base: string;
+  dir: string;
+  ext: string;
+  name: string;
+};
+
+export type {
+  FileContent,
+  FileMap,
+  FilePath,
+  FilePathMap,
+  Options,
+  ParsedPath,
+};

--- a/packages/files/tests/files/parse-file-path/base-case.test.ts
+++ b/packages/files/tests/files/parse-file-path/base-case.test.ts
@@ -1,0 +1,16 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { parseFilePath } from '../../../src/index.js';
+
+test('files | parse-file-path > base case', function () {
+  const filePath = 'src/components/navigation-menu.hbs';
+
+  const parsedPath = parseFilePath(filePath);
+
+  assert.deepEqual(parsedPath, {
+    base: 'navigation-menu.hbs',
+    dir: 'src/components',
+    ext: '.hbs',
+    name: 'navigation-menu',
+  });
+});

--- a/packages/files/tests/files/parse-file-path/edge-case-css-d-ts.test.ts
+++ b/packages/files/tests/files/parse-file-path/edge-case-css-d-ts.test.ts
@@ -1,0 +1,16 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { parseFilePath } from '../../../src/index.js';
+
+test('files | parse-file-path > edge case (.css.d.ts)', function () {
+  const filePath = 'src/components/navigation-menu.css.d.ts';
+
+  const parsedPath = parseFilePath(filePath);
+
+  assert.deepEqual(parsedPath, {
+    base: 'navigation-menu.css.d.ts',
+    dir: 'src/components',
+    ext: '.css.d.ts',
+    name: 'navigation-menu',
+  });
+});

--- a/packages/files/tests/files/parse-file-path/edge-case-d-ts.test.ts
+++ b/packages/files/tests/files/parse-file-path/edge-case-d-ts.test.ts
@@ -1,0 +1,16 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { parseFilePath } from '../../../src/index.js';
+
+test('files | parse-file-path > edge case (.d.ts)', function () {
+  const filePath = 'src/components/navigation-menu.d.ts';
+
+  const parsedPath = parseFilePath(filePath);
+
+  assert.deepEqual(parsedPath, {
+    base: 'navigation-menu.d.ts',
+    dir: 'src/components',
+    ext: '.d.ts',
+    name: 'navigation-menu',
+  });
+});

--- a/packages/files/tests/files/parse-file-path/edge-case-no-directory.test.ts
+++ b/packages/files/tests/files/parse-file-path/edge-case-no-directory.test.ts
@@ -1,0 +1,16 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { parseFilePath } from '../../../src/index.js';
+
+test('files | parse-file-path > edge case (no directory)', function () {
+  const filePath = 'README.md';
+
+  const parsedPath = parseFilePath(filePath);
+
+  assert.deepEqual(parsedPath, {
+    base: 'README.md',
+    dir: '',
+    ext: '.md',
+    name: 'README',
+  });
+});

--- a/packages/files/tests/files/parse-file-path/edge-case-no-extension.test.ts
+++ b/packages/files/tests/files/parse-file-path/edge-case-no-extension.test.ts
@@ -1,0 +1,16 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { parseFilePath } from '../../../src/index.js';
+
+test('files | parse-file-path > edge case (no extension)', function () {
+  const filePath = '.gitignore';
+
+  const parsedPath = parseFilePath(filePath);
+
+  assert.deepEqual(parsedPath, {
+    base: '.gitignore',
+    dir: '',
+    ext: '',
+    name: '.gitignore',
+  });
+});

--- a/packages/files/tests/files/parse-file-path/edge-case-special-characters.test.ts
+++ b/packages/files/tests/files/parse-file-path/edge-case-special-characters.test.ts
@@ -1,0 +1,16 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { parseFilePath } from '../../../src/index.js';
+
+test('files | parse-file-path > edge case (special characters)', function () {
+  const filePath = 'photos/image (1).png';
+
+  const parsedPath = parseFilePath(filePath);
+
+  assert.deepEqual(parsedPath, {
+    base: 'image (1).png',
+    dir: 'photos',
+    ext: '.png',
+    name: 'image (1)',
+  });
+});


### PR DESCRIPTION
## Description

Currently, `renamePathByFile` implements `parseFilePath` as a private method. As there may be soon a need for `parseFilePath`, I exported it so that I can parse file paths in a consistent manner.

```ts
import { parse } from 'node:path';

const filePath = 'src/components/navigation-menu.d.ts';
const { base, dir, ext, name } = parse(filePath);

/*
  base = 'navigation-menu.d.ts'
  dir = 'src/components'
  ext = '.ts' ❌
  name = 'navigation-menu.d' ❌
*/
```

```ts
import { parseFilePath } from '@codemod-utils/files';

const filePath = 'src/components/navigation-menu.d.ts';
const { base, dir, ext, name } = parseFilePath(filePath);

/*
  base = 'navigation-menu.d.ts'
  dir = 'src/components'
  ext = '.d.ts' ✅
  name = 'navigation-menu' ✅
*/
```
