### PR TITLE
Added link to the CI status badge

### DIFF
--- a/.changeset/two-pears-film.md
+++ b/.changeset/two-pears-film.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/cli": patch
+---
+
+Added link to the CI status badge

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,9 +24,11 @@ git init
 git add .
 git commit -m "Initial commit"
 git branch -M main
-git remote add origin git@github.com:<your-GitHub-handle>/<your-repo-name>.git
+git remote add origin git@github.com:<your-github-handle>/<your-repo-name>.git
 git push -u origin main
 ```
+
+Before pushing to the repository, consider updating `README.md` (e.g. link to the CI status badge).
 
 
 ### Arguments

--- a/packages/cli/src/blueprints/README.md
+++ b/packages/cli/src/blueprints/README.md
@@ -1,3 +1,5 @@
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+
 # <%= options.codemod.name %>
 
 _Codemod to [PROVIDE A SHORT DESCRIPTION.]_

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/README.md
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/README.md
@@ -1,3 +1,5 @@
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+
 # ember-codemod-args-to-signature
 
 _Codemod to [PROVIDE A SHORT DESCRIPTION.]_

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/README.md
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/README.md
@@ -1,3 +1,5 @@
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+
 # ember-codemod-pod-to-octane
 
 _Codemod to [PROVIDE A SHORT DESCRIPTION.]_

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/README.md
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/README.md
@@ -1,3 +1,5 @@
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+
 # ember-codemod-args-to-signature
 
 _Codemod to [PROVIDE A SHORT DESCRIPTION.]_

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/README.md
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/README.md
@@ -1,3 +1,5 @@
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+
 # ember-codemod-pod-to-octane
 
 _Codemod to [PROVIDE A SHORT DESCRIPTION.]_


### PR DESCRIPTION
## Description

`@codemod-utils/cli` creates a GitHub Actions workflow so that CI (continuous integration) is available out of the box. Displaying the status badge in `README.md` may help maintainers or users of the codemod address issues early.


## Screenshots

- If the end-developer pushes the initial commit without changing the URL, they will see that the link is broken.

    <img width="640" alt="" src="https://github.com/ijlee2/codemod-utils/assets/16869656/509cd593-957e-4f55-9dc7-e6004daf94ca">

- Once they update the URL, they will see the CI status badge (note that CI passed out of the box).

    <img width="640" alt="" src="https://github.com/ijlee2/codemod-utils/assets/16869656/4787fc60-f85a-4e38-be8d-5a95cb9b1708">
