### PR TITLE
Simplified blueprint for prettier configuration

### DIFF
--- a/.changeset/quick-lizards-stare.md
+++ b/.changeset/quick-lizards-stare.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/cli": patch
+---
+
+Simplified blueprint for prettier configuration

--- a/configs/prettier/.prettierrc.js
+++ b/configs/prettier/.prettierrc.js
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/src/blueprints/.prettierrc.cjs
+++ b/packages/cli/src/blueprints/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.prettierrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         printWidth: 80,
         singleQuote: true,
-        trailingComma: 'all',
       },
     },
   ],


### PR DESCRIPTION
## Description

In `prettier@v3`, `trailingComma` is set to `'all'` by default.