### PR TITLE
Changed @sondr3/minitest to be a peer dependency

### DIFF
--- a/.changeset/lovely-cooks-cross.md
+++ b/.changeset/lovely-cooks-cross.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/tests": minor
+---
+
+Changed @sondr3/minitest to be a peer dependency

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -45,7 +45,6 @@
     "test": "./build.sh --test && echo '@codemod-utils/tests does not have tests.'"
   },
   "dependencies": {
-    "@sondr3/minitest": "^0.1.1",
     "fixturify": "^3.0.0",
     "glob": "^10.3.3"
   },


### PR DESCRIPTION
## Background

In a Node project, when [`@sondr3/minitest`](https://github.com/sondr3/minitest) is installed as a dependency, we can run its executable (called `mt`) to run tests easily:

```json5
/* Example: @codemod-utils/ast-javascript */
{
  "scripts: {
    "test": "./build.sh --test && mt dist-for-testing --quiet"
  }
}
```

`@codemod-utils/tests@v0.2.5` (and earlier versions) had `@sondr3/minitest` as a dependency so that the consuming project wouldn't need to install it themselves. However, I couldn't figure out how to update the `test` script, i.e. how to replace the command `mt` with `node_modules/<some path>/mt`.


## What changed?

For simplicity (that is, allow the `test` script to continue to show the `mt` command), we'll ask the consuming project to install `@sondr3/minitest` as a development dependency. This already happens when we use `@codemod-utils/cli` to create a codemod project.

In effect, removing `@sondr3/minitest` as a dependency from `@codemod-utils/tests` will prevent the consuming project from potentially installing two versions of `@sondr3/minitest`.
