### PR TITLE
Removed unnecessary eslint-disable comments in the main tutorial

### DIFF
--- a/tutorials/ember-codemod-rename-test-modules/05-step-1-update-acceptance-tests-part-2.md
+++ b/tutorials/ember-codemod-rename-test-modules/05-step-1-update-acceptance-tests-part-2.md
@@ -460,10 +460,7 @@ Once you arrive at an implementation in AST Explorer, moving the code to the cod
 
 <summary>Solution: <code>src/steps/rename-acceptance-tests.ts</code></summary>
 
-Disabling `@typescript-eslint/no-unsafe-member-access` isn't really a part of the change. (This may be required in `@typescript-eslint@v6`?) Pretend that it's not there. 🙈
-
 ```diff
-+ /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -596,7 +593,6 @@ Currently, `data.moduleName` is hard-coded. We can derive the test module name f
 The implementation for `renameModule()` remains unchanged and has been hidden for simplicity.
 
 ```diff
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/tutorials/ember-codemod-rename-test-modules/06-step-2-update-integration-tests.md
+++ b/tutorials/ember-codemod-rename-test-modules/06-step-2-update-integration-tests.md
@@ -178,7 +178,6 @@ Try copy-pasting the starter code to `rename-integration-tests`, then remove ref
 I highlighted only how `getModuleName()` and `renameModule()` differ between `rename-acceptance-tests` and `rename-integration-tests`.
 
 ```diff
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -419,7 +418,6 @@ In short, I took the simplest approach to quickly implement a step. Later, after
 The implementations for `renameModule()` and `renameIntegrationTests()` remain unchanged and have been hidden for simplicity.
 
 ```diff
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/tutorials/ember-codemod-rename-test-modules/07-step-3-update-unit-tests.md
+++ b/tutorials/ember-codemod-rename-test-modules/07-step-3-update-unit-tests.md
@@ -22,7 +22,6 @@ I highlighted only the differences between `rename-integration-tests` and `renam
 Note that, because `'instance-initializers'` and `'utils'` need to be mapped to the words `'Instance Initializer'` and `'Utility'`, installing a package that has `singularize()` and `capitalize()` wouldn't be enough. Again, avoid premature abstractions.
 
 ```diff
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/tutorials/ember-codemod-rename-test-modules/08-refactor-code-part-1.md
+++ b/tutorials/ember-codemod-rename-test-modules/08-refactor-code-part-1.md
@@ -173,7 +173,6 @@ export * from './rename-module.js';
 <summary>Solution: <code>src/utils/rename-tests/rename-module.ts</code></summary>
 
 ```ts
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 type Data = {
@@ -226,7 +225,6 @@ export function renameModule(file: string, data: Data): string {
 <summary>Solution: <code>src/steps/rename-tests/rename-acceptance-tests.ts</code></summary>
 
 ```diff
-- /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -261,7 +259,6 @@ export function renameAcceptanceTests(options: Options): void {
 <summary>Solution: <code>src/steps/rename-tests/rename-integration-tests.ts</code></summary>
 
 ```diff
-- /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -304,7 +301,6 @@ export function renameIntegrationTests(options: Options): void {
 <summary>Solution: <code>src/steps/rename-tests/rename-unit-tests.ts</code></summary>
 
 ```diff
-- /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 


### PR DESCRIPTION
## Background

In #71, I updated `@codemod-utils/cli` so that the `eslint` configuration is relaxed. This means, by default, codemod projects rely on `@typescript-eslint`'s `recommended` rules (instead of `recommended-type-checking`).