### PR TITLE
Set decoratorsBeforeExport to true, to match the default configuration for Ember projects

### DIFF
--- a/.changeset/red-ravens-build.md
+++ b/.changeset/red-ravens-build.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/ast-javascript": minor
+---
+
+Set decoratorsBeforeExport to true, to match the default configuration for Ember projects

--- a/packages/ast/javascript/src/ast/javascript.ts
+++ b/packages/ast/javascript/src/ast/javascript.ts
@@ -36,7 +36,7 @@ const jsOptions: ParserOptions = {
     'dynamicImport',
     'nullishCoalescingOperator',
     'optionalChaining',
-    ['decorators', { decoratorsBeforeExport: false }],
+    ['decorators', { decoratorsBeforeExport: true }],
   ],
 };
 


### PR DESCRIPTION
## Background

`@codemod-utils/ast-javascript`'s configurations for `@babel/parser` had been copied from `jscodeshift`.

From [a recent fork](https://github.com/ijlee2/codemod-utils/commit/a7121edd12493a06625ef7f39e204ab6074bd4a9), I realized that it's better to set `decoratorsBeforeExport` to `true`, because it matches the [default configuration for Ember projects](https://github.com/ember-cli/ember-cli/blob/v5.2.1/blueprints/app/files/.eslintrc.js#L12).

According to [Babel](https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport):

> This option:
>
> - is disallowed when using `version: "legacy"`, `version: "2022-03"`, `version: "2023-01"`, or `version: "2023-05"`;
> - is required when using `version: "2018-09"`;
> - is optional and defaults to `false` when using `version: "2021-12"`.
>
> ```ts
> // decoratorsBeforeExport: false
> export @decorator class Bar {}
>
> // decoratorsBeforeExport: true
> @decorator
> export class Foo {}
> ```
>
> This option was originally added to help tc39 collect feedback from the community by allowing experimentation with the proposed syntaxes. The proposal has now settled on allowing decorators either before or after export.


## Notes

Changing the `decoratorsBeforeExport` to `true` may affect codemods that look at JavaScript files. In practice, however, I don't think this will occur often enough that I'd need to consider this pull request a breaking change.

For all of my codemods that depend on `@codemod-utils/ast-javascript`, the tests continued to pass after I patched the package by setting `decoratorsBeforeExport` to `true`.

- [x] `ember-codemod-args-to-signature`
- [x] `ember-codemod-rename-test-modules`
- [x] `ember-codemod-remove-ember-css-modules`
