### PR TITLE
Added JSDoc to @codemod-utils/files

### DIFF
--- a/.changeset/thirty-meals-pay.md
+++ b/.changeset/thirty-meals-pay.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/files": minor
+---
+
+Added JSDoc

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -12,31 +12,29 @@ _Utilities for handling files_
 
 ## API
 
-Many of the methods make use of the **file path**, a string that represents the location of a file. Therefore, I recommend learning [`findFiles`](#findfiles-unionize) first, as it returns the paths of all files that match the search criteria.
+Many of the methods make use of the **file path**, a string that represents the location of a file. Therefore, I recommend learning [`findFiles`](#findfiles) first, as it returns the paths of all files that match the search criteria.
 
 
 ### copyFiles
 
-Copy files from one directory to another.
+Copies files from one directory (source) to another (destination). Creates the destination directory if it doesn't exist.
 
 <details>
 
 <summary>Example</summary>
 
-In [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), we want to copy some files from the project root to the addon package.
+Copy `LICENSE.md` and `README.md` from the project root to the folder `ember-container-query`.
 
-```js
-import { copyFiles, mapFilePaths } from '@codemod-utils/files';
+```ts
+import { copyFiles } from '@codemod-utils/files';
 
-const filePaths = [/* ... */];
-
-const filePathMap = mapFilePaths(filePaths, {
-  from: '',
-  to: '__addonLocation__',
-});
+const filePathMap = new Map([
+  ['LICENSE.md', 'ember-container-query/LICENSE.md'],
+  ['README.md', 'ember-container-query/README.md'],
+]);
 
 copyFiles(filePathMap, {
-  projectRoot: '__projectRoot__',
+  projectRoot,
 });
 ```
 
@@ -45,20 +43,39 @@ copyFiles(filePathMap, {
 
 ### createDirectory
 
-Ensure that, given a file path, the directories exist.
+Creates the directories specified in the file path, if they don't exist yet.
 
-⚠️ Likely, you won't need this method. Call [`createFiles`](#createfiles) instead.
-
-
-### createFiles
-
-Create files in bulk. You will need to provide a mapping between file paths and file contents.
+⚠️ Likely, you won't need this method but [`createFiles`](#createfiles) instead.
 
 <details>
 
 <summary>Example</summary>
 
-```js
+Create the folder `ember-container-query` if it doesn't exist.
+
+```ts
+import { createDirectory } from '@codemod-utils/files';
+
+const newFilePath = 'ember-container-query/LICENSE.md';
+const destination = join(projectRoot, newFilePath);
+
+createDirectory(destination);
+```
+
+</details>
+
+
+### createFiles
+
+Create files. Creates the destination directory if it doesn't exist.
+
+<details>
+
+<summary>Example</summary>
+
+Create `LICENSE.md` and `README.md` in the project root.
+
+```ts
 import { createFiles } from '@codemod-utils/files';
 
 const fileMap = new Map([
@@ -67,14 +84,14 @@ const fileMap = new Map([
 ]);
 
 createFiles(fileMap, {
-  projectRoot: '__projectRoot__',
+  projectRoot,
 });
 ```
 
 </details>
 
 
-### findFiles, unionize
+### findFiles
 
 Often, you will want a codemod step to apply to select files. `findFiles` provides the paths of all files that match your search criteria (i.e. [glob pattern](https://github.com/isaacs/node-glob#glob-primer), ignore list, and project root). The paths are sorted in alphabetical order.
 
@@ -82,13 +99,13 @@ Often, you will want a codemod step to apply to select files. `findFiles` provid
 
 <summary>Example</summary>
 
-In [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), we want to move the `tests/dummy` folder to the test-app package.
+Find all component templates in an Ember app.
 
-```js
+```ts
 import { findfiles } from '@codemod-utils/files';
 
-const filePaths = findFiles('tests/dummy/**/*', {
-  projectRoot: '__projectRoot__',
+const filePaths = findFiles('app/components/**/*.hbs', {
+  projectRoot,
 });
 ```
 
@@ -100,32 +117,44 @@ You can provide `ignoreList`, an array of file paths or glob patterns, to exclud
 
 <summary>Example</summary>
 
-In [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), we want to move some files in `tests` to the test-app package's `tests` folder.
+Find all component classes in an Ember app.
 
-```js
+```ts
 import { findfiles } from '@codemod-utils/files';
 
-const filePaths = findFiles('tests/**/*', {
-  ignoreList: ['tests/dummy/**/*'],
-  projectRoot: '__projectRoot__',
+const filePaths = findFiles('app/components/**/*.{js,ts}', {
+  ignoreList: ['**/*.d.ts'],
+  projectRoot,
 });
 ```
 
 </details>
 
-Lastly, you can use `unionize` to look for multiple files ("possibly file A or file B or ..."):
+To look for multiple types of files, you can pass an array of glob patterns (pattern A or pattern B or ...).
 
 <details>
 
-<summary>Example</summary>
+<summary>Examples</summary>
 
-```js
-import { findfiles, unionize } from '@codemod-utils/files';
+```ts
+import { findfiles } from '@codemod-utils/files';
 
-const files = ['LICENSE.md', 'README.md'];
+const filePaths = findFiles([
+  'LICENSE.md',
+  'README.md',
+], {
+  projectRoot,
+});
+```
 
-const filePaths = findFiles(unionize(files), {
-  projectRoot: '__projectRoot__',
+```ts
+import { findfiles } from '@codemod-utils/files';
+
+const filePaths = findFiles([
+  'app/components/**/*.hbs',
+  'tests/integration/components/**/*-test.{js,ts}',
+], {
+  projectRoot,
 });
 ```
 
@@ -134,31 +163,48 @@ const filePaths = findFiles(unionize(files), {
 
 ### mapFilePaths
 
-Create a mapping of file paths, which can be passed to [`createFiles`](#createfiles) or [`moveFiles`](#movefiles). 
-
-
-### moveFiles
-
-Move files from one directory to another.
+Creates a mapping of file paths, which can then be passed to [`copyFiles`](#copyfiles) or [`moveFiles`](#movefiles). 
 
 <details>
 
 <summary>Example</summary>
 
-In [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), we want to move some files from the project root to the test-app package.
+Map `LICENSE.md` to `ember-container-query/LICENSE.md` (and similarly for `README.md`).
 
-```js
-import { mapFilePaths, moveFiles } from '@codemod-utils/files';
+```ts
+import { mapFilePaths } from '@codemod-utils/files';
 
-const filePaths = [/* ... */];
+const filePaths = ['LICENSE.md', 'README.md'];
 
 const filePathMap = mapFilePaths(filePaths, {
   from: '',
-  to: '__testAppLocation__',
+  to: 'ember-container-query',
 });
+```
+
+</details>
+
+
+### moveFiles
+
+Moves files from one directory (source) to another (destination). Creates the destination directory if it doesn't exist. Removes the source directory if it is empty.
+
+<details>
+
+<summary>Example</summary>
+
+Move `LICENSE.md` and `README.md` from the project root to a folder named `ember-container-query`.
+
+```ts
+import { moveFiles } from '@codemod-utils/files';
+
+const filePathMap = new Map([
+  ['LICENSE.md', 'ember-container-query/LICENSE.md'],
+  ['README.md', 'ember-container-query/README.md'],
+]);
 
 moveFiles(filePathMap, {
-  projectRoot: '__projectRoot__',
+  projectRoot,
 });
 ```
 
@@ -167,24 +213,22 @@ moveFiles(filePathMap, {
 
 ### parseFilePath
 
-Parse a file path, just like you can with `parse` from `node:path`. `parseFilePath` can handle file extensions with more than one `.` (e.g. `.d.ts`, `.css.d.ts`).
+Parses a file path, similarly to `parse()` from `node:path`, but correctly handles file extensions with more than one `.`, e.g. `.d.ts` and `.css.d.ts`.
 
 <details>
 
 <summary>Example</summary>
 
-```js
+```ts
 import { parseFilePath } from '@codemod-utils/files';
 
 const filePath = 'src/components/navigation-menu.d.ts';
 const { base, dir, ext, name } = parseFilePath(filePath);
 
-/*
-  base = 'navigation-menu.d.ts'
-  dir = 'src/components'
-  ext = '.d.ts'
-  name = 'navigation-menu'
-*/
+// base -> 'navigation-menu.d.ts'
+// dir  -> 'src/components'
+// ext  -> '.d.ts'
+// name -> 'navigation-menu'
 ```
 
 </details>
@@ -192,26 +236,46 @@ const { base, dir, ext, name } = parseFilePath(filePath);
 
 ### removeDirectoryIfEmpty
 
-Ensure that, after deleting a file, the directories in the file path are removed if empty.
+Removes the directories specified in the file path, if they are empty.
 
-⚠️ Likely, you won't need this method. Call [`removeFiles`](#removefiles) instead.
-
-
-### removeFiles
-
-Remove files in bulk.
+⚠️ Likely, you won't need this method but [`removeFiles`](#removefiles) instead.
 
 <details>
 
 <summary>Example</summary>
 
-```js
+Remove the folder `ember-container-query` if it is empty.
+
+```ts
+import { removeDirectoryIfEmpty } from '@codemod-utils/files';
+
+const filePath = 'ember-container-query/LICENSE.md';
+
+removeDirectoryIfEmpty(filePath, {
+  projectRoot,
+});
+```
+
+</details>
+
+
+### removeFiles
+
+Removes files. Removes the source directory if it is empty.
+
+<details>
+
+<summary>Example</summary>
+
+Remove `LICENSE.md` and `README.md` from the project root.
+
+```ts
 import { removeFiles } from '@codemod-utils/files';
 
 const filePaths = ['LICENSE.md', 'README.md'];
 
 removeFiles(filePaths, {
-  projectRoot: '__projectRoot__',
+  projectRoot,
 });
 ```
 
@@ -220,33 +284,25 @@ removeFiles(filePaths, {
 
 ### renamePathByDirectory
 
-Get a new file path by altering the path's directory.
+Forms a new file path by altering the path's directory.
 
 <details>
 
 <summary>Example</summary>
 
-In [`ember-codemod-v1-to-v2`](https://github.com/ijlee2/ember-codemod-v1-to-v2/), we want to compute `appReexports`. To do so, we find all files in the `app` folder, then remove the word `app` from each file path.
+Prepare to move components from `addon` to `ember-container-query/src`.
 
-```js
+```ts
 import { findFiles, renamePathByDirectory } from '@codemod-utils/files';
 
-function getAppReexports(options) {
-  const { projectRoot } = options;
+const oldFilePath = 'addon/components/container-query.hbs';
 
-  const filePaths = findFiles('app/**/*.js', {
-    cwd: projectRoot,
-  });
+const newFilePath = renamePathByDirectory(oldFilePath, {
+  from: 'addon',
+  to: 'ember-container-query/src',
+});
 
-  return filePaths
-    .map((filePath) => {
-      return renameDirectory(filePath, {
-        from: 'app',
-        to: '',
-      });
-    })
-    .sort();
-}
+// newFilePath -> 'ember-container-query/src/components/container-query.hbs'
 ```
 
 </details>
@@ -254,38 +310,30 @@ function getAppReexports(options) {
 
 ### renamePathByFile
 
-Get a new file path by altering the path's file name.
+Forms a new file path by altering the path's file name.
 
 <details>
 
 <summary>Example</summary>
 
-In [`ember-codemod-pod-to-octane`](https://github.com/ijlee2/ember-codemod-pod-to-octane/), we want to "un-pod" components. To do so, we find all files in the `app/components` folder, then adjust the file name.
+Prepare to un-pod components.
 
-```js
+```ts
 import { findFiles, renamePathByFile } from '@codemod-utils/files';
 
-function migrationStrategyForComponentClasses(options) {
-  const { projectRoot } = options;
+const oldFilePath = 'app/components/navigation-menu/template.hbs';
 
-  const filePaths = findFiles('app/components/**/component.{d.ts,js,ts}', {
-    projectRoot,
-  });
+const newFilePath = renamePathByFile(oldFilePath, {
+  find: {
+    directory: 'app/components',
+    file: 'template',
+  },
+  replace: (key: string) => {
+    return `app/components/${key}`;
+  },
+});
 
-  return filePaths.map((oldFilePath) => {
-    const newFilePath = renamePathByFile(oldFilePath, {
-      find: {
-        directory: 'app/components',
-        file: 'component',
-      },
-      replace: (key) => {
-        return `app/components/${key}`;
-      },
-    });
-
-    return [oldFilePath, newFilePath];
-  });
-}
+// newFilePath -> 'app/components/navigation-menu.hbs'
 ```
 
 </details>

--- a/packages/files/src/files/copy-files.ts
+++ b/packages/files/src/files/copy-files.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import type { FilePathMap, Options } from '../types/index.js';
 import { createDirectory } from './create-directory.js';
 
-export function copyFiles(filePathMap: FilePathMap, options: Options): void {
+export function copyFiles(
+  filePathMap: FilePathMap,
+  options: Options & {
+    projectRoot: string;
+  },
+): void {
   const { projectRoot } = options;
 
   filePathMap.forEach((newFilePath, oldFilePath) => {

--- a/packages/files/src/files/copy-files.ts
+++ b/packages/files/src/files/copy-files.ts
@@ -4,6 +4,34 @@ import { join } from 'node:path';
 import type { FilePathMap, Options } from '../types/index.js';
 import { createDirectory } from './create-directory.js';
 
+/**
+ * Copies files from one directory (source) to another (destination).
+ * Creates the destination directory if it doesn't exist.
+ *
+ * @param filePathMap
+ *
+ * A mapping from source to destination.
+ *
+ * @param options
+ *
+ * An object with `projectRoot`.
+ *
+ * @example
+ *
+ * Copy `LICENSE.md` and `README.md` from the project root to the
+ * folder `ember-container-query`.
+ *
+ * ```ts
+ * const filePathMap = new Map([
+ *   ['LICENSE.md', 'ember-container-query/LICENSE.md'],
+ *   ['README.md', 'ember-container-query/README.md'],
+ * ]);
+ *
+ * copyFiles(filePathMap, {
+ *   projectRoot,
+ * });
+ * ```
+ */
 export function copyFiles(
   filePathMap: FilePathMap,
   options: Options & {

--- a/packages/files/src/files/create-directory.ts
+++ b/packages/files/src/files/create-directory.ts
@@ -3,6 +3,27 @@ import { dirname } from 'node:path';
 
 import type { FilePath } from '../types/index.js';
 
+/**
+ * Creates the directories specified in the file path, if they don't
+ * exist yet.
+ *
+ * ⚠️ Likely, you won't need this method but `createFiles()` instead.
+ *
+ * @param filePath
+ *
+ * A file path.
+ *
+ * @example
+ *
+ * Create the folder `ember-container-query` if it doesn't exist.
+ *
+ * ```ts
+ * const newFilePath = 'ember-container-query/LICENSE.md';
+ * const destination = join(projectRoot, newFilePath);
+ *
+ * createDirectory(destination);
+ * ```
+ */
 export function createDirectory(filePath: FilePath): void {
   const directory = dirname(filePath);
 

--- a/packages/files/src/files/create-files.ts
+++ b/packages/files/src/files/create-files.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import type { FileMap, Options } from '../types/index.js';
 import { createDirectory } from './create-directory.js';
 
-export function createFiles(fileMap: FileMap, options: Options): void {
+export function createFiles(
+  fileMap: FileMap,
+  options: Options & {
+    projectRoot: string;
+  },
+): void {
   const { projectRoot } = options;
 
   fileMap.forEach((file, filePath) => {

--- a/packages/files/src/files/create-files.ts
+++ b/packages/files/src/files/create-files.ts
@@ -4,6 +4,33 @@ import { join } from 'node:path';
 import type { FileMap, Options } from '../types/index.js';
 import { createDirectory } from './create-directory.js';
 
+/**
+ * Creates files. Creates the destination directory if it doesn't
+ * exist.
+ *
+ * @param fileMap
+ *
+ * A mapping between the file path and the file content (UTF-8).
+ *
+ * @param options
+ *
+ * An object with `projectRoot`.
+ *
+ * @example
+ *
+ * Create `LICENSE.md` and `README.md` in the project root.
+ *
+ * ```ts
+ * const fileMap = new Map([
+ *   ['LICENSE.md', 'The MIT License (MIT)'],
+ *   ['README.md', '# ember-container-query'],
+ * ]);
+ *
+ * createFiles(fileMap, {
+ *   projectRoot,
+ * });
+ * ```
+ */
 export function createFiles(
   fileMap: FileMap,
   options: Options & {

--- a/packages/files/src/files/find-files.ts
+++ b/packages/files/src/files/find-files.ts
@@ -4,7 +4,7 @@ import type { FilePath, Options } from '../types/index.js';
 
 export function findFiles(
   pattern: string | string[],
-  options: Options & { ignoreList?: string[] },
+  options: Options & { ignoreList?: string[]; projectRoot: string },
 ): FilePath[] {
   const { ignoreList = [], projectRoot } = options;
 

--- a/packages/files/src/files/find-files.ts
+++ b/packages/files/src/files/find-files.ts
@@ -2,6 +2,67 @@ import { globSync } from 'glob';
 
 import type { FilePath, Options } from '../types/index.js';
 
+/**
+ * Returns the paths of all files that match your search criteria
+ * (i.e. {@link https://github.com/isaacs/node-glob#glob-primer | glob pattern}, ignore list, and project root).
+ * The paths are sorted in alphabetical order.
+ *
+ * @param pattern
+ *
+ * A glob pattern that describes which files you are looking for.
+ *
+ * @param options
+ *
+ * An object with `ignoreList` (an array of file paths or glob
+ * patterns) and `projectRoot`.
+ *
+ * @return
+ *
+ * Paths of all files that match your search criteria.
+ *
+ * @example
+ *
+ * Find all component templates in an Ember app.
+ *
+ * ```ts
+ * const filePaths = findFiles('app/components/**\/*.hbs', {
+ *   projectRoot,
+ * });
+ * ```
+ *
+ * @example
+ *
+ * Find all component classes in an Ember app.
+ *
+ * ```ts
+ * const filePaths = findFiles('app/components/**\/*.{js,ts}', {
+ *   ignoreList: ['**\/*.d.ts'],
+ *   projectRoot,
+ * });
+ * ```
+ *
+ * @example
+ *
+ * Pass an array of glob patterns (pattern A or pattern B or ...).
+ *
+ * ```ts
+ * const filePaths = findFiles([
+ *   'LICENSE.md',
+ *   'README.md',
+ * ], {
+ *   projectRoot,
+ * });
+ * ```
+ *
+ * ```ts
+ * const filePaths = findFiles([
+ *   'app/components/**\/*.hbs',
+ *   'tests/integration/components/**\/*-test.{js,ts}',
+ * ], {
+ *   projectRoot,
+ * });
+ * ```
+ */
 export function findFiles(
   pattern: string | string[],
   options: Options & { ignoreList?: string[]; projectRoot: string },

--- a/packages/files/src/files/find-files.ts
+++ b/packages/files/src/files/find-files.ts
@@ -25,11 +25,3 @@ export function findFiles(
 
   return filePaths.sort();
 }
-
-export function unionize(files: string[]): string {
-  if (files.length <= 1) {
-    return files.join(',');
-  }
-
-  return `{${files.join(',')}}`;
-}

--- a/packages/files/src/files/map-file-paths.ts
+++ b/packages/files/src/files/map-file-paths.ts
@@ -1,6 +1,32 @@
 import type { FilePath } from '../types/index.js';
 import { renamePathByDirectory } from './rename-path-by-directory.js';
 
+/**
+ * Creates a mapping of file paths, which can then be passed to
+ * `copyFiles()` or `moveFiles()`.
+ *
+ * @param filePaths
+ *
+ * An array of file paths. The array may come from `findFiles()`.
+ *
+ * @param options
+ *
+ * An object with `from` and `to`.
+ *
+ * @example
+ *
+ * Map `LICENSE.md` to `ember-container-query/LICENSE.md` (and
+ * similarly for `README.md`).
+ *
+ * ```ts
+ * const filePaths = ['LICENSE.md', 'README.md'];
+ *
+ * const filePathMap = mapFilePaths(filePaths, {
+ *   from: '',
+ *   to: 'ember-container-query',
+ * });
+ * ```
+ */
 export function mapFilePaths(
   filePaths: FilePath[],
   options: {

--- a/packages/files/src/files/map-file-paths.ts
+++ b/packages/files/src/files/map-file-paths.ts
@@ -1,12 +1,13 @@
 import type { FilePath } from '../types/index.js';
 import { renamePathByDirectory } from './rename-path-by-directory.js';
 
-type Options = {
-  from: string;
-  to: string;
-};
-
-export function mapFilePaths(filePaths: FilePath[], options: Options) {
+export function mapFilePaths(
+  filePaths: FilePath[],
+  options: {
+    from: string;
+    to: string;
+  },
+) {
   const { from, to } = options;
 
   return new Map(

--- a/packages/files/src/files/move-files.ts
+++ b/packages/files/src/files/move-files.ts
@@ -5,7 +5,12 @@ import type { FilePathMap, Options } from '../types/index.js';
 import { createDirectory } from './create-directory.js';
 import { removeDirectoryIfEmpty } from './remove-directory-if-empty.js';
 
-export function moveFiles(filePathMap: FilePathMap, options: Options): void {
+export function moveFiles(
+  filePathMap: FilePathMap,
+  options: Options & {
+    projectRoot: string;
+  },
+): void {
   const { projectRoot } = options;
 
   filePathMap.forEach((newFilePath, oldFilePath) => {

--- a/packages/files/src/files/move-files.ts
+++ b/packages/files/src/files/move-files.ts
@@ -5,6 +5,35 @@ import type { FilePathMap, Options } from '../types/index.js';
 import { createDirectory } from './create-directory.js';
 import { removeDirectoryIfEmpty } from './remove-directory-if-empty.js';
 
+/**
+ * Moves files from one directory (source) to another (destination).
+ * Creates the destination directory if it doesn't exist. Removes
+ * the source directory if it is empty.
+ *
+ * @param filePathMap
+ *
+ * A mapping from source to destination.
+ *
+ * @param options
+ *
+ * An object with `projectRoot`.
+ *
+ * @example
+ *
+ * Move `LICENSE.md` and `README.md` from the project root to a
+ * folder named `ember-container-query`.
+ *
+ * ```ts
+ * const filePathMap = new Map([
+ *   ['LICENSE.md', 'ember-container-query/LICENSE.md'],
+ *   ['README.md', 'ember-container-query/README.md'],
+ * ]);
+ *
+ * moveFiles(filePathMap, {
+ *   projectRoot,
+ * });
+ * ```
+ */
 export function moveFiles(
   filePathMap: FilePathMap,
   options: Options & {

--- a/packages/files/src/files/parse-file-path.ts
+++ b/packages/files/src/files/parse-file-path.ts
@@ -2,6 +2,31 @@ import { parse } from 'node:path';
 
 import type { FilePath, ParsedPath } from '../types/index.js';
 
+/**
+ * Parses a file path, similarly to `parse()` from `node:path`,
+ * but correctly handles file extensions with more than one `.`,
+ * e.g. `.d.ts` and `.css.d.ts`.
+ *
+ * @param filePath
+ *
+ * A file path.
+ *
+ * @return
+ *
+ * An object with `base`, `dir`, `ext`, and `name`.
+ *
+ * @example
+ *
+ * ```ts
+ * const filePath = 'src/components/navigation-menu.d.ts';
+ * const { base, dir, ext, name } = parseFilePath(filePath);
+ *
+ * // base -> 'navigation-menu.d.ts'
+ * // dir  -> 'src/components'
+ * // ext  -> '.d.ts'
+ * // name -> 'navigation-menu'
+ * ```
+ */
 export function parseFilePath(filePath: FilePath): ParsedPath {
   // eslint-disable-next-line prefer-const
   let { base, dir, ext, name } = parse(filePath);

--- a/packages/files/src/files/remove-directory-if-empty.ts
+++ b/packages/files/src/files/remove-directory-if-empty.ts
@@ -5,7 +5,9 @@ import type { FilePath, Options } from '../types/index.js';
 
 export function removeDirectoryIfEmpty(
   filePath: FilePath,
-  options: Options,
+  options: Options & {
+    projectRoot: string;
+  },
 ): void {
   const { projectRoot } = options;
 

--- a/packages/files/src/files/remove-directory-if-empty.ts
+++ b/packages/files/src/files/remove-directory-if-empty.ts
@@ -3,6 +3,32 @@ import { dirname, join } from 'node:path';
 
 import type { FilePath, Options } from '../types/index.js';
 
+/**
+ * Removes the directories specified in the file path, if they are
+ * empty.
+ *
+ * ⚠️ Likely, you won't need this method but `removeFiles()` instead.
+ *
+ * @param filePath
+ *
+ * A file path.
+ *
+ * @param options
+ *
+ * An object with `projectRoot`.
+ *
+ * @example
+ *
+ * Remove the folder `ember-container-query` if it is empty.
+ *
+ * ```ts
+ * const filePath = 'ember-container-query/LICENSE.md';
+ *
+ * removeDirectoryIfEmpty(filePath, {
+ *   projectRoot,
+ * });
+ * ```
+ */
 export function removeDirectoryIfEmpty(
   filePath: FilePath,
   options: Options & {

--- a/packages/files/src/files/remove-files.ts
+++ b/packages/files/src/files/remove-files.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import type { FilePath, Options } from '../types/index.js';
 import { removeDirectoryIfEmpty } from './remove-directory-if-empty.js';
 
-export function removeFiles(filePaths: FilePath[], options: Options): void {
+export function removeFiles(
+  filePaths: FilePath[],
+  options: Options & {
+    projectRoot: string;
+  },
+): void {
   const { projectRoot } = options;
 
   filePaths.forEach((filePath) => {

--- a/packages/files/src/files/remove-files.ts
+++ b/packages/files/src/files/remove-files.ts
@@ -4,6 +4,29 @@ import { join } from 'node:path';
 import type { FilePath, Options } from '../types/index.js';
 import { removeDirectoryIfEmpty } from './remove-directory-if-empty.js';
 
+/**
+ * Removes files. Removes the source directory if it is empty.
+ *
+ * @param filePaths
+ *
+ * An array of file paths.
+ *
+ * @param options
+ *
+ * An object with `projectRoot`.
+ *
+ * @example
+ *
+ * Remove `LICENSE.md` and `README.md` from the project root.
+ *
+ * ```ts
+ * const filePaths = ['LICENSE.md', 'README.md'];
+ *
+ * removeFiles(filePaths, {
+ *   projectRoot,
+ * });
+ * ```
+ */
 export function removeFiles(
   filePaths: FilePath[],
   options: Options & {

--- a/packages/files/src/files/rename-path-by-directory.ts
+++ b/packages/files/src/files/rename-path-by-directory.ts
@@ -2,14 +2,12 @@ import { join } from 'node:path';
 
 import type { FilePath } from '../types/index.js';
 
-type Options = {
-  from: string;
-  to: string;
-};
-
 export function renamePathByDirectory(
   filePath: FilePath,
-  options: Options,
+  options: {
+    from: string;
+    to: string;
+  },
 ): FilePath {
   const { from, to } = options;
 

--- a/packages/files/src/files/rename-path-by-directory.ts
+++ b/packages/files/src/files/rename-path-by-directory.ts
@@ -2,6 +2,36 @@ import { join } from 'node:path';
 
 import type { FilePath } from '../types/index.js';
 
+/**
+ * Forms a new file path by altering the path's directory.
+ *
+ * @param filePath
+ *
+ * A file path.
+ *
+ * @param options
+ *
+ * An object with `from` and `to`.
+ *
+ * @return
+ *
+ * A file path.
+ *
+ * @example
+ *
+ * Prepare to move components from `addon` to `ember-container-query/src`.
+ *
+ * ```ts
+ * const oldFilePath = 'addon/components/container-query.hbs';
+ *
+ * const newFilePath = renamePathByDirectory(oldFilePath, {
+ *   from: 'addon',
+ *   to: 'ember-container-query/src',
+ * });
+ *
+ * // newFilePath -> 'ember-container-query/src/components/container-query.hbs'
+ * ```
+ */
 export function renamePathByDirectory(
   filePath: FilePath,
   options: {

--- a/packages/files/src/files/rename-path-by-file.ts
+++ b/packages/files/src/files/rename-path-by-file.ts
@@ -1,6 +1,41 @@
 import type { FilePath } from '../types/index.js';
 import { parseFilePath } from './parse-file-path.js';
 
+/**
+ * Forms a new file path by altering the path's file name.
+ *
+ * @param filePath
+ *
+ * A file path.
+ *
+ * @param options
+ *
+ * An object with `find` and `replace`.
+ *
+ * @return
+ *
+ * A file path.
+ *
+ * @example
+ *
+ * Prepare to un-pod components.
+ *
+ * ```ts
+ * const oldFilePath = 'app/components/navigation-menu/template.hbs';
+ *
+ * const newFilePath = renamePathByFile(oldFilePath, {
+ *   find: {
+ *     directory: 'app/components',
+ *     file: 'template',
+ *   },
+ *   replace: (key: string) => {
+ *     return `app/components/${key}`;
+ *   },
+ * });
+ *
+ * // newFilePath -> 'app/components/navigation-menu.hbs'
+ * ```
+ */
 export function renamePathByFile(
   filePath: FilePath,
   options: {

--- a/packages/files/src/files/rename-path-by-file.ts
+++ b/packages/files/src/files/rename-path-by-file.ts
@@ -1,17 +1,15 @@
 import type { FilePath } from '../types/index.js';
 import { parseFilePath } from './parse-file-path.js';
 
-type Options = {
-  find: {
-    directory: string;
-    file: string;
-  };
-  replace: (key: string) => string;
-};
-
 export function renamePathByFile(
   filePath: FilePath,
-  options: Options,
+  options: {
+    find: {
+      directory: string;
+      file: string;
+    };
+    replace: (key: string) => string;
+  },
 ): FilePath {
   const { dir, ext, name } = parseFilePath(filePath);
   const { find, replace } = options;

--- a/packages/files/src/files/unionize.ts
+++ b/packages/files/src/files/unionize.ts
@@ -1,3 +1,32 @@
+/**
+ * Returns the glob pattern that can search multiple files
+ * ("file A or file B or ..."). The glob pattern is to be
+ * passed to `findFiles()`.
+ *
+ * @param files
+ *
+ * An array of file paths.
+ *
+ * @return
+ *
+ * A glob pattern that can be passed to `findFiles()`.
+ *
+ * @example
+ *
+ * Look for multiple files:
+ *
+ * ```ts
+ * const pattern = unionize([
+ *   'package-lock.json',
+ *   'pnpm-lock.yaml',
+ *   'yarn.lock',
+ * ]);
+ *
+ * const filePaths = findFiles(pattern, {
+ *   projectRoot,
+ * });
+ * ```
+ */
 export function unionize(files: string[]): string {
   if (files.length <= 1) {
     return files.join(',');

--- a/packages/files/src/files/unionize.ts
+++ b/packages/files/src/files/unionize.ts
@@ -1,0 +1,7 @@
+export function unionize(files: string[]): string {
+  if (files.length <= 1) {
+    return files.join(',');
+  }
+
+  return `{${files.join(',')}}`;
+}

--- a/packages/files/src/files/unionize.ts
+++ b/packages/files/src/files/unionize.ts
@@ -3,6 +3,10 @@
  * ("file A or file B or ..."). The glob pattern is to be
  * passed to `findFiles()`.
  *
+ * @deprecated
+ *
+ * Pass an array of glob patterns to `findFiles()` instead.
+ *
  * @param files
  *
  * An array of file paths.

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -9,4 +9,5 @@ export * from './files/remove-directory-if-empty.js';
 export * from './files/remove-files.js';
 export * from './files/rename-path-by-directory.js';
 export * from './files/rename-path-by-file.js';
+export * from './files/unionize.js';
 export * from './types/index.js';

--- a/packages/files/src/types/index.ts
+++ b/packages/files/src/types/index.ts
@@ -6,10 +6,7 @@ type FilePath = string;
 
 type FilePathMap = Map<FilePath, FilePath>;
 
-type Options = {
-  [key: string]: unknown;
-  projectRoot: string;
-};
+type Options = Record<string, unknown>;
 
 type ParsedPath = {
   base: string;

--- a/packages/files/tests/files/find-files/multiple-patterns.test.ts
+++ b/packages/files/tests/files/find-files/multiple-patterns.test.ts
@@ -1,9 +1,9 @@
 import { assert, loadFixture, test } from '@codemod-utils/tests';
 
 import { findFiles } from '../../../src/index.js';
-import { codemodOptions } from '../../shared-test-setups/index.js';
+import { codemodOptions, options } from '../../shared-test-setups/index.js';
 
-test('files | find-files > edge case (projectRoot does not exist)', function () {
+test('files | find-files > multiple patterns', function () {
   const inputProject = {
     tests: {
       dummy: {
@@ -34,9 +34,15 @@ test('files | find-files > edge case (projectRoot does not exist)', function () 
 
   loadFixture(inputProject, codemodOptions);
 
-  const filePaths = findFiles('tests/dummy/**/*.{js,ts}', {
-    projectRoot: 'path/to/somewhere/else',
+  const filePaths = findFiles(['**/*.json', '**/index.*'], {
+    projectRoot: options.projectRoot,
   });
 
-  assert.deepStrictEqual(filePaths, []);
+  assert.deepStrictEqual(filePaths, [
+    'index.js',
+    'package.json',
+    'tests/dummy/app/index.html',
+    'tests/dummy/config/optional-features.json',
+    'tests/index.html',
+  ]);
 });

--- a/packages/files/tests/files/map-file-paths/base-case.test.ts
+++ b/packages/files/tests/files/map-file-paths/base-case.test.ts
@@ -3,21 +3,21 @@ import { assert, test } from '@codemod-utils/tests';
 import { mapFilePaths } from '../../../src/index.js';
 
 test('files | map-file-paths > base case', function () {
-  const filePaths = ['addon/some-folder/some-file.ts', 'addon/.gitkeep'];
+  const filePaths = ['addon/components/container-query.hbs', 'addon/.gitkeep'];
 
   const filePathMap = mapFilePaths(filePaths, {
     from: 'addon',
-    to: 'new-location/src',
+    to: 'ember-container-query/src',
   });
 
   assert.deepStrictEqual(
     filePathMap,
     new Map([
       [
-        'addon/some-folder/some-file.ts',
-        'new-location/src/some-folder/some-file.ts',
+        'addon/components/container-query.hbs',
+        'ember-container-query/src/components/container-query.hbs',
       ],
-      ['addon/.gitkeep', 'new-location/src/.gitkeep'],
+      ['addon/.gitkeep', 'ember-container-query/src/.gitkeep'],
     ]),
   );
 });

--- a/packages/files/tests/files/map-file-paths/edge-case-no-match.test.ts
+++ b/packages/files/tests/files/map-file-paths/edge-case-no-match.test.ts
@@ -7,7 +7,7 @@ test('files | map-file-paths > edge case (no match)', function () {
 
   const filePathMap = mapFilePaths(filePaths, {
     from: 'addon',
-    to: 'new-location/src',
+    to: 'ember-container-query/src',
   });
 
   assert.deepStrictEqual(

--- a/packages/files/tests/files/rename-path-by-directory/base-case.test.ts
+++ b/packages/files/tests/files/rename-path-by-directory/base-case.test.ts
@@ -3,12 +3,15 @@ import { assert, test } from '@codemod-utils/tests';
 import { renamePathByDirectory } from '../../../src/index.js';
 
 test('files | rename-path-by-directory > base case', function () {
-  const oldFilePath = 'addon/some-folder/some-file.ts';
+  const oldFilePath = 'addon/components/container-query.hbs';
 
   const newFilePath = renamePathByDirectory(oldFilePath, {
     from: 'addon',
-    to: 'new-location/src',
+    to: 'ember-container-query/src',
   });
 
-  assert.strictEqual(newFilePath, 'new-location/src/some-folder/some-file.ts');
+  assert.strictEqual(
+    newFilePath,
+    'ember-container-query/src/components/container-query.hbs',
+  );
 });

--- a/packages/files/tests/files/rename-path-by-directory/edge-case-from-is-empty.test.ts
+++ b/packages/files/tests/files/rename-path-by-directory/edge-case-from-is-empty.test.ts
@@ -3,15 +3,15 @@ import { assert, test } from '@codemod-utils/tests';
 import { renamePathByDirectory } from '../../../src/index.js';
 
 test('files | rename-path-by-directory > edge case (from is empty)', function () {
-  const oldFilePath = 'addon/some-folder/some-file.ts';
+  const oldFilePath = 'addon/components/container-query.hbs';
 
   const newFilePath = renamePathByDirectory(oldFilePath, {
     from: '',
-    to: 'new-location/src',
+    to: 'ember-container-query/src',
   });
 
   assert.strictEqual(
     newFilePath,
-    'new-location/src/addon/some-folder/some-file.ts',
+    'ember-container-query/src/addon/components/container-query.hbs',
   );
 });

--- a/packages/files/tests/files/rename-path-by-directory/edge-case-no-match.test.ts
+++ b/packages/files/tests/files/rename-path-by-directory/edge-case-no-match.test.ts
@@ -7,7 +7,7 @@ test('files | rename-path-by-directory > edge case (no match)', function () {
 
   const newFilePath = renamePathByDirectory(oldFilePath, {
     from: 'addon',
-    to: 'new-location/src',
+    to: 'ember-container-query/src',
   });
 
   assert.strictEqual(newFilePath, 'addon');

--- a/packages/files/tests/files/rename-path-by-directory/edge-case-to-is-empty.test.ts
+++ b/packages/files/tests/files/rename-path-by-directory/edge-case-to-is-empty.test.ts
@@ -3,12 +3,12 @@ import { assert, test } from '@codemod-utils/tests';
 import { renamePathByDirectory } from '../../../src/index.js';
 
 test('files | rename-path-by-directory > edge case (to is empty)', function () {
-  const oldFilePath = 'addon/some-folder/some-file.ts';
+  const oldFilePath = 'addon/components/container-query.hbs';
 
   const newFilePath = renamePathByDirectory(oldFilePath, {
     from: 'addon',
     to: '',
   });
 
-  assert.strictEqual(newFilePath, 'some-folder/some-file.ts');
+  assert.strictEqual(newFilePath, 'components/container-query.hbs');
 });

--- a/packages/files/tests/files/unionize/base-case.test.ts
+++ b/packages/files/tests/files/unionize/base-case.test.ts
@@ -1,0 +1,13 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { unionize } from '../../../src/index.js';
+
+test('files | unionize > base case', function () {
+  const pattern = unionize([
+    'package-lock.json',
+    'pnpm-lock.yaml',
+    'yarn.lock',
+  ]);
+
+  assert.strictEqual(pattern, '{package-lock.json,pnpm-lock.yaml,yarn.lock}');
+});

--- a/packages/files/tests/files/unionize/edge-case-no-file-paths.test.ts
+++ b/packages/files/tests/files/unionize/edge-case-no-file-paths.test.ts
@@ -1,0 +1,9 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { unionize } from '../../../src/index.js';
+
+test('files | unionize > edge case (no file paths)', function () {
+  const pattern = unionize([]);
+
+  assert.strictEqual(pattern, '');
+});

--- a/packages/files/tests/files/unionize/edge-case-one-file-path.test.ts
+++ b/packages/files/tests/files/unionize/edge-case-one-file-path.test.ts
@@ -1,0 +1,9 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { unionize } from '../../../src/index.js';
+
+test('files | unionize > edge case (1 file path)', function () {
+  const pattern = unionize(['README.md']);
+
+  assert.strictEqual(pattern, 'README.md');
+});


### PR DESCRIPTION
## Description

I added JSDoc to `@codemod-utils/files` so that end-developers have an additional source for learning, besides the package's `README.md` and tests (both are unavailable offline) as well as its provided types (requires some familiarity with TypeScript). In addition, I updated the `README.md` to show more simple examples.

Note, the `breaking` label is due to `unionize()` being deprecated (it will be removed later).


## Screenshots

Before:

<img width="900" alt="We see the type information for findFiles but nothing else." src="https://github.com/ijlee2/codemod-utils/assets/16869656/43383c42-6200-46c2-bc4b-978b52d2b6e5">

After:

<img width="900" alt="In addition to type information, we see a detailed explanation for the inputs and outputs of findFiles, along with a few examples." src="https://github.com/ijlee2/codemod-utils/assets/16869656/3474c6fd-a028-4703-9382-8f23c30ef6a4">
