### PR TITLE
Updated pnpm.overrides to show the correct version for eslint-plugin-import

### DIFF
--- a/.changeset/late-hairs-cough.md
+++ b/.changeset/late-hairs-cough.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/cli": patch
+---
+
+Updated pnpm.overrides to show the correct version for eslint-plugin-import

--- a/packages/cli/src/blueprints/package.json
+++ b/packages/cli/src/blueprints/package.json
@@ -47,7 +47,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.28.1>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }<% } else { %>{

--- a/packages/cli/src/blueprints/package.json
+++ b/packages/cli/src/blueprints/package.json
@@ -44,11 +44,6 @@
       "enhance: dependency": "Internal",
       "enhance: documentation": "Documentation"
     }
-  },
-  "pnpm": {
-    "overrides": {
-      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
-    }
   }
 }<% } else { %>{
   "name": "<%= options.codemod.name %>",

--- a/packages/cli/src/migration/steps/update-package-json.ts
+++ b/packages/cli/src/migration/steps/update-package-json.ts
@@ -77,6 +77,22 @@ function updateDevDependencies(
   packageJson['devDependencies'] = convertToObject(devDependencies);
 }
 
+function addPnpmOverrides(packageJson: PackageJson, options: Options): void {
+  const { codemod } = options;
+
+  if (!codemod.hasTypeScript) {
+    return;
+  }
+
+  const version = getVersion('eslint-plugin-import').replace(/^\^/, '');
+
+  packageJson['pnpm'] = {
+    overrides: {
+      [`eslint-plugin-import@${version}>tsconfig-paths`]: '^4.2.0',
+    },
+  };
+}
+
 export function updatePackageJson(options: Options): void {
   const { codemod, projectRoot } = options;
 
@@ -86,6 +102,7 @@ export function updatePackageJson(options: Options): void {
 
   updateDependencies(packageJson, options);
   updateDevDependencies(packageJson, options);
+  addPnpmOverrides(packageJson, options);
 
   const destination = join(projectRoot, codemod.name, 'package.json');
   const file = JSON.stringify(packageJson, null, 2) + '\n';

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -47,7 +47,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.28.1>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -44,10 +44,5 @@
       "enhance: dependency": "Internal",
       "enhance: documentation": "Documentation"
     }
-  },
-  "pnpm": {
-    "overrides": {
-      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/package.json
@@ -47,7 +47,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.28.1>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/package.json
@@ -44,10 +44,5 @@
       "enhance: dependency": "Internal",
       "enhance: documentation": "Documentation"
     }
-  },
-  "pnpm": {
-    "overrides": {
-      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/input/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/input/ember-codemod-args-to-signature/package.json
@@ -47,7 +47,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.27.5>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -77,7 +77,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.27.5>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript/input/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript/input/ember-codemod-pod-to-octane/package.json
@@ -47,7 +47,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.27.5>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript/output/ember-codemod-pod-to-octane/package.json
@@ -72,7 +72,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.27.5>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -77,7 +77,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.28.1>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/package.json
@@ -72,7 +72,7 @@
   },
   "pnpm": {
     "overrides": {
-      "eslint-plugin-import@2.28.1>tsconfig-paths": "^4.2.0"
+      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
     }
   }
 }


### PR DESCRIPTION
## Description

In #91, I updated `latestVersions` to add `eslint-plugin-import@2.29.0`, but forgot to also update the version in `pnpm.overrides`.

To prevent this error from happening again, I updated the `update-package-json` to define `pnpm.overrides`.
