### PR TITLE
Replace lerna-changelog with changesets

### DIFF
--- a/.changeset/brown-snails-walk.md
+++ b/.changeset/brown-snails-walk.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/cli": minor
+---
+
+Replaced lerna-changelog with changesets"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/codemod-utils.git
+    git clone git@github.com:<your-github-handle>/codemod-utils.git
     ```
 
 1. Change directory.
@@ -84,13 +84,13 @@ Here are some guidelines to help you and everyone else.
 
 <summary>Publish packages (for admins)</summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
 
-1. Run the `publish:changelogs` script. This removes changesets, updates the package versions, and updates the `CHANGELOG`'s.
+1. Run the `release:changelog` script. This removes changesets, updates the package versions, and updates the `CHANGELOG`'s.
 
     ```sh
     # From the workspace root
-    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm publish:changelogs
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
     ```
 
 1. The workspace root's version (e.g. `0.1.3`) is more of an identifier than a (semantic) version. We will use it to name the tag that will be published.
@@ -110,7 +110,7 @@ Here are some guidelines to help you and everyone else.
 
     ```sh
     # From the workspace root
-    pnpm publish:packages
+    pnpm release:package
     ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -12,12 +12,11 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter './packages/**' build",
-    "changeset": "changeset add",
     "lint": "pnpm --filter '*' lint",
     "lint:fix": "pnpm --filter '*' lint:fix",
     "prepare": "pnpm build",
-    "publish:changelogs": "changeset version",
-    "publish:packages": "changeset publish",
+    "release:changelog": "changeset version",
+    "release:package": "pnpm build && changeset publish",
     "test": "pnpm --filter '*' test"
   },
   "devDependencies": {

--- a/packages/cli/src/blueprints/.changeset/config.json
+++ b/packages/cli/src/blueprints/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/src/blueprints/.changeset/formatter.cjs
+++ b/packages/cli/src/blueprints/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/<%= options.codemod.name %>';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/src/blueprints/CONTRIBUTING.md
+++ b/packages/cli/src/blueprints/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/<%= options.codemod.name %>.git
+    git clone git@github.com:<your-github-handle>/<%= options.codemod.name %>.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/<%= options.codemod.name %>/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/src/blueprints/README.md
+++ b/packages/cli/src/blueprints/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<%= options.codemod.name %>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<%= options.codemod.name %>/actions/workflows/ci.yml)
 
 # <%= options.codemod.name %>
 

--- a/packages/cli/src/blueprints/package.json
+++ b/packages/cli/src/blueprints/package.json
@@ -22,7 +22,6 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
@@ -35,15 +34,6 @@
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }<% } else { %>{
   "name": "<%= options.codemod.name %>",
@@ -69,7 +59,6 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
@@ -80,14 +69,5 @@
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }<% } %>

--- a/packages/cli/src/blueprints/package.json
+++ b/packages/cli/src/blueprints/package.json
@@ -28,6 +28,8 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {},
@@ -63,6 +65,8 @@
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {},

--- a/packages/cli/src/migration/steps/update-package-json.ts
+++ b/packages/cli/src/migration/steps/update-package-json.ts
@@ -42,6 +42,8 @@ function updateDevDependencies(
   const packagesToInstall = new Set([
     '@babel/core',
     '@babel/eslint-parser',
+    '@changesets/cli',
+    '@changesets/get-github-info',
     '@codemod-utils/tests',
     '@sondr3/minitest',
     'concurrently',

--- a/packages/cli/src/migration/steps/update-package-json.ts
+++ b/packages/cli/src/migration/steps/update-package-json.ts
@@ -51,7 +51,6 @@ function updateDevDependencies(
     'eslint-plugin-n',
     'eslint-plugin-prettier',
     'eslint-plugin-simple-import-sort',
-    'lerna-changelog',
     'prettier',
   ]);
 

--- a/packages/cli/src/utils/blueprints/get-version.ts
+++ b/packages/cli/src/utils/blueprints/get-version.ts
@@ -26,7 +26,6 @@ const latestVersions = new Map([
   ['eslint-plugin-prettier', '5.0.1'],
   ['eslint-plugin-simple-import-sort', '10.0.0'],
   ['eslint-plugin-typescript-sort-keys', '3.1.0'],
-  ['lerna-changelog', '2.2.0'],
   ['prettier', '3.0.3'],
   ['typescript', '5.2.2'],
   ['yargs', '17.7.2'],

--- a/packages/cli/src/utils/blueprints/get-version.ts
+++ b/packages/cli/src/utils/blueprints/get-version.ts
@@ -3,6 +3,8 @@ import { decideVersion } from '@codemod-utils/blueprints';
 const latestVersions = new Map([
   ['@babel/core', '7.23.2'],
   ['@babel/eslint-parser', '7.22.15'],
+  ['@changesets/cli', '2.26.2'],
+  ['@changesets/get-github-info', '0.5.2'],
   ['@codemod-utils/ast-javascript', '1.2.0'],
   ['@codemod-utils/ast-template', '1.1.0'],
   ['@codemod-utils/blueprints', '1.1.0'],

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-args-to-signature';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-args-to-signature.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-args-to-signature.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/README.md
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml)
 
 # ember-codemod-args-to-signature
 

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -22,11 +22,12 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {
@@ -41,6 +42,8 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "concurrently": "^8.2.1",
@@ -50,19 +53,9 @@
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.changeset/config.json
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-pod-to-octane';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-pod-to-octane.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-pod-to-octane.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/README.md
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml)
 
 # ember-codemod-pod-to-octane
 

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/package.json
@@ -22,11 +22,12 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {
@@ -36,6 +37,8 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "concurrently": "^8.2.1",
@@ -45,19 +48,9 @@
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-args-to-signature';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-args-to-signature.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-args-to-signature.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/README.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml)
 
 # ember-codemod-args-to-signature
 

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -22,25 +22,17 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/.changeset/config.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-pod-to-octane';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-pod-to-octane.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-pod-to-octane.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/README.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml)
 
 # ember-codemod-pod-to-octane
 

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-codemod-pod-to-octane/package.json
@@ -22,25 +22,17 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-args-to-signature';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-args-to-signature.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-args-to-signature.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/README.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml)
 
 # ember-codemod-args-to-signature
 

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -22,27 +22,19 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/.changeset/config.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-pod-to-octane';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-pod-to-octane.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-pod-to-octane.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/README.md
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml)
 
 # ember-codemod-pod-to-octane
 

--- a/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-codemod-pod-to-octane/package.json
@@ -22,27 +22,19 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/javascript-with-addons/input/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/javascript-with-addons/input/ember-codemod-args-to-signature/package.json
@@ -22,25 +22,17 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -22,11 +22,12 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {
@@ -41,6 +42,8 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "concurrently": "^8.2.1",
@@ -50,19 +53,9 @@
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/javascript/input/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/javascript/input/ember-codemod-pod-to-octane/package.json
@@ -22,25 +22,17 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/javascript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/javascript/output/ember-codemod-pod-to-octane/package.json
@@ -22,11 +22,12 @@
     "src"
   ],
   "scripts": {
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release:changelog": "changeset version",
+    "release:publish": "changeset publish",
     "test": "mt tests --quiet"
   },
   "dependencies": {
@@ -36,6 +37,8 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "concurrently": "^8.2.1",
@@ -45,19 +48,9 @@
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/input/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/input/ember-codemod-args-to-signature/package.json
@@ -22,32 +22,19 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
-  },
-  "pnpm": {
-    "overrides": {
-      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -22,13 +22,14 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {
@@ -42,6 +43,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "@tsconfig/node18": "^18.2.2",
@@ -59,21 +62,11 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-typescript-sort-keys": "^3.1.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   },
   "pnpm": {
     "overrides": {

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript/input/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript/input/ember-codemod-pod-to-octane/package.json
@@ -22,32 +22,19 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
-  },
-  "pnpm": {
-    "overrides": {
-      "eslint-plugin-import@2.29.0>tsconfig-paths": "^4.2.0"
-    }
   }
 }

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript/output/ember-codemod-pod-to-octane/package.json
@@ -22,13 +22,14 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {
@@ -37,6 +38,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "@tsconfig/node18": "^18.2.2",
@@ -54,21 +57,11 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-typescript-sort-keys": "^3.1.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   },
   "pnpm": {
     "overrides": {

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-args-to-signature';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-args-to-signature.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-args-to-signature.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/README.md
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-args-to-signature/actions/workflows/ci.yml)
 
 # ember-codemod-args-to-signature
 

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -22,13 +22,14 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {
@@ -42,6 +43,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "@tsconfig/node18": "^18.2.2",
@@ -59,21 +62,11 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-typescript-sort-keys": "^3.1.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   },
   "pnpm": {
     "overrides": {

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.changeset/config.json
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "./formatter.cjs",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.changeset/formatter.cjs
@@ -1,0 +1,43 @@
+const { getInfo } = require('@changesets/get-github-info');
+
+const repo = '<your-github-handle>/ember-codemod-pod-to-octane';
+
+async function extractInformation(changeset) {
+  const { links: info } = await getInfo({
+    commit: changeset.commit,
+    repo,
+  });
+
+  const contributor = info.user ? `(${info.user})` : undefined;
+  const link = info.pull ?? info.commit ?? undefined;
+  const summary = (changeset.summary ?? '').split('\n')[0].trim();
+
+  return {
+    contributor,
+    link,
+    summary,
+  };
+}
+
+function getDependencyReleaseLine() {
+  return '';
+}
+
+async function getReleaseLine(changeset) {
+  try {
+    const { contributor, link, summary } = await extractInformation(changeset);
+
+    const line = [link, summary, contributor].filter(Boolean).join(' ');
+
+    return `- ${line}`;
+  } catch (error) {
+    console.error(`ERROR: getReleaseLine (${error.message})`);
+
+    return '';
+  }
+}
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some guidelines to help you and everyone else.
 1. Fork and clone this repo.
 
     ```sh
-    git clone git@github.com:<your GitHub handle>/ember-codemod-pod-to-octane.git
+    git clone git@github.com:<your-github-handle>/ember-codemod-pod-to-octane.git
     ```
 
 1. Change directory.
@@ -66,24 +66,37 @@ Here are some guidelines to help you and everyone else.
 
 <details>
 
-<summary>Publish packages (for admins)</summary>
+<summary>Add changeset to pull request</code></summary>
 
-1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with default values for scopes (none selected).
+1. To record how a pull request affects packages, you will want to add a changeset.
 
-1. Run the `changelog` script. This generates a text that you can add to `CHANGELOG.md`.
+    The changeset provides a summary of the code change. It also describes how package versions should be updated (major, minor, or patch) as a result of the code change.
 
     ```sh
-    GITHUB_AUTH=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm changelog
+    pnpm changeset
     ```
 
-1. The package follows [semantic versioning](https://semver.org/). Update the version in `package.json` accordingly.
+</details>
 
-1. Create a tag and provide release notes. The tag name should match the package version.
+
+<details>
+
+<summary>Publish package (for admins)</summary>
+
+1. Generate a [personal access token](https://github.com/settings/tokens/) in GitHub, with `repo` and `read:user` scopes enabled.
+
+1. Run the `release:changelog` script. This removes changesets, updates the package version, and updates the `CHANGELOG`.
+
+    ```sh
+    GITHUB_TOKEN=<YOUR_PERSONAL_ACCESS_TOKEN> pnpm release:changelog
+    ```
+
+1. [Create a tag](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/releases/new) and provide release notes. The tag name should match the package version.
 
 1. Publish the package.
 
     ```sh
-    pnpm publish
+    pnpm release:package
     ```
 
 </details>

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/README.md
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/README.md
@@ -1,4 +1,4 @@
-[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/<your-repo-name>/actions/workflows/ci.yml)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml/badge.svg)](https://github.com/<your-github-handle>/ember-codemod-pod-to-octane/actions/workflows/ci.yml)
 
 # ember-codemod-pod-to-octane
 

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/package.json
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/package.json
@@ -22,13 +22,14 @@
   ],
   "scripts": {
     "build": "./build.sh --production",
-    "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
+    "release:changelog": "changeset version",
+    "release:publish": "pnpm build && changeset publish",
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {
@@ -37,6 +38,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
+    "@changesets/cli": "^2.26.2",
+    "@changesets/get-github-info": "^0.5.2",
     "@codemod-utils/tests": "^1.1.1",
     "@sondr3/minitest": "^0.1.2",
     "@tsconfig/node18": "^18.2.2",
@@ -54,21 +57,11 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-typescript-sort-keys": "^3.1.0",
-    "lerna-changelog": "^2.2.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
   },
   "engines": {
     "node": "18.* || >= 20"
-  },
-  "changelog": {
-    "labels": {
-      "breaking": "Breaking Change",
-      "bug": "Bug Fix",
-      "enhance: code": "Enhancement",
-      "enhance: dependency": "Internal",
-      "enhance: documentation": "Documentation"
-    }
   },
   "pnpm": {
     "overrides": {

--- a/tutorials/ember-codemod-rename-test-modules/01-create-a-project.md
+++ b/tutorials/ember-codemod-rename-test-modules/01-create-a-project.md
@@ -62,9 +62,11 @@ Try running these scripts now. They should pass out of the box.
 
 The CLI added a few placeholders. At some point—before the initial commit or, at the latest, before publishing your codemod—you will want to manually update these files:
 
+- `.changeset/formatter.cjs` - link to the GitHub repo
+- `CONTRIBUTING.md` - link to the GitHub repo
 - `LICENSE.md` - copyright information
 - `package.json` - `author`, `description`, `repository` (remove `private` to publish the codemod)
-- `README.md` - link to the CI status badge, codemod description and usage
+- `README.md` - link to the GitHub repo, codemod description, codemod options
 
 
 <div align="center">


### PR DESCRIPTION
## Description

I updated `@codemod-utils/cli` so that, by default, codemod projects use `changesets` to update `CHANGELOG.md` and publish the package. [`pnpm` recommends changesets](https://pnpm.io/using-changesets) and we might see more frequent releases (in comparison, [`lerna-changelog`](https://github.com/lerna/lerna-changelog) hasn't had a release since October 2021).


## Why `@changesets/get-github-info`?

The built-in implementations ([`@changesets/changelog-git`](https://github.com/changesets/changesets/blob/%40changesets/changelog-git%400.1.14/packages/changelog-git/src/index.ts) and [`@changesets/changelog-github`](https://github.com/changesets/changesets/blob/%40changesets/changelog-github%400.4.8/packages/changelog-github/src/index.ts)) currently pose a large technical risk (the code is complex and in need of refactoring) and generate `CHANGELOG`'s that I don't find useful.

<details>

<summary>With <code>@changesets/changelog-git</code></summary>

```md
## 0.1.2

### Patch Changes

- f8f2bef: Third attempt at publishing packages
```
</details>

<details>

<summary>With <code>@changesets/changelog-github</code></summary>

```md
## 0.1.2

### Patch Changes

- [#13](https://github.com/ijlee2/my-project/pull/13) [`f8f2bef`](https://github.com/ijlee2/my-project/commit/f8f2bef08dc907458b0d9e9acabe6301ae0559d0) Thanks [@ijlee2](https://github.com/ijlee2)! - Third attempt at publishing packages
```
</details>

With a custom formatter, we can create `CHANGELOG`'s that help maintainers and end-developers (users) more. The output is inspired from `lerna-changelog` and will look like:

```md
## 0.1.2

### Patch Changes

- [#13](https://github.com/ijlee2/my-project/pull/13) Third attempt at publishing packages ([@ijlee2](https://github.com/ijlee2))
```