### PR TITLE
Replaced lodash.template with lodash

### DIFF
--- a/.changeset/smooth-zoos-hunt.md
+++ b/.changeset/smooth-zoos-hunt.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/blueprints": patch
+---
+
+Replaced lodash.template with lodash

--- a/packages/blueprints/package.json
+++ b/packages/blueprints/package.json
@@ -45,7 +45,7 @@
     "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {
-    "lodash.template": "^4.5.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@codemod-utils/tests": "workspace:*",
@@ -53,7 +53,7 @@
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
     "@sondr3/minitest": "^0.1.2",
-    "@types/lodash.template": "^4.5.3",
+    "@types/lodash": "^4.17.0",
     "@types/node": "^18.19.31",
     "concurrently": "^8.2.2",
     "eslint": "^8.57.0",

--- a/packages/blueprints/src/blueprints/process-template.ts
+++ b/packages/blueprints/src/blueprints/process-template.ts
@@ -1,4 +1,5 @@
-import template from 'lodash.template';
+// eslint-disable-next-line n/no-missing-import
+import template from 'lodash/template.js';
 
 /**
  * Returns the blueprint file after filling it out with data.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,9 +177,9 @@ importers:
 
   packages/blueprints:
     dependencies:
-      lodash.template:
-        specifier: ^4.5.0
-        version: 4.5.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@codemod-utils/tests':
         specifier: workspace:*
@@ -196,9 +196,9 @@ importers:
       '@sondr3/minitest':
         specifier: ^0.1.2
         version: 0.1.2
-      '@types/lodash.template':
-        specifier: ^4.5.3
-        version: 4.5.3
+      '@types/lodash':
+        specifier: ^4.17.0
+        version: 4.17.0
       '@types/node':
         specifier: ^18.19.31
         version: 18.19.31
@@ -2978,29 +2978,12 @@ packages:
     dependencies:
       p-locate: 5.0.0
 
-  /lodash._reinterpolate@3.0.0:
-    resolution: {integrity: sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==}
-    dev: false
-
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
-
-  /lodash.template@4.5.0:
-    resolution: {integrity: sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==}
-    dependencies:
-      lodash._reinterpolate: 3.0.0
-      lodash.templatesettings: 4.2.0
-    dev: false
-
-  /lodash.templatesettings@4.2.0:
-    resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
-    dependencies:
-      lodash._reinterpolate: 3.0.0
-    dev: false
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}


### PR DESCRIPTION
## Description

Addresses https://github.com/ijlee2/codemod-utils/security/dependabot/1.

End-users of the resulting codemods [shouldn't have been affected](https://github.com/lodash/lodash/issues/5851#issuecomment-2069634388), but replacing the package now would help developers writing codemods have one less thing to worry.
