### PR TITLE
Corrected latest version for @codemod-utils/ast-template

### DIFF
--- a/.changeset/friendly-monkeys-sniff.md
+++ b/.changeset/friendly-monkeys-sniff.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/cli": patch
+---
+
+Corrected latest version for @codemod-utils/ast-template

--- a/packages/cli/src/utils/blueprints/get-version.ts
+++ b/packages/cli/src/utils/blueprints/get-version.ts
@@ -6,7 +6,7 @@ const latestVersions = new Map([
   ['@changesets/cli', '2.27.5'],
   ['@changesets/get-github-info', '0.6.0'],
   ['@codemod-utils/ast-javascript', '1.2.6'],
-  ['@codemod-utils/ast-template', '1.1.3'],
+  ['@codemod-utils/ast-template', '1.1.2'],
   ['@codemod-utils/blueprints', '1.1.3'],
   ['@codemod-utils/ember-cli-string', '1.1.2'],
   ['@codemod-utils/files', '2.0.2'],

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@codemod-utils/ast-javascript": "^1.2.6",
-    "@codemod-utils/ast-template": "^1.1.3",
+    "@codemod-utils/ast-template": "^1.1.2",
     "@codemod-utils/blueprints": "^1.1.3",
     "@codemod-utils/ember-cli-string": "^1.1.2",
     "@codemod-utils/files": "^2.0.2",

--- a/packages/cli/tests/fixtures/steps/update-package-json/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/javascript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@codemod-utils/ast-javascript": "^1.2.6",
-    "@codemod-utils/ast-template": "^1.1.3",
+    "@codemod-utils/ast-template": "^1.1.2",
     "@codemod-utils/blueprints": "^1.1.3",
     "@codemod-utils/ember-cli-string": "^1.1.2",
     "@codemod-utils/files": "^2.0.2",

--- a/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/steps/update-package-json/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@codemod-utils/ast-javascript": "^1.2.6",
-    "@codemod-utils/ast-template": "^1.1.3",
+    "@codemod-utils/ast-template": "^1.1.2",
     "@codemod-utils/blueprints": "^1.1.3",
     "@codemod-utils/ember-cli-string": "^1.1.2",
     "@codemod-utils/files": "^2.0.2",

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@codemod-utils/ast-javascript": "^1.2.6",
-    "@codemod-utils/ast-template": "^1.1.3",
+    "@codemod-utils/ast-template": "^1.1.2",
     "@codemod-utils/blueprints": "^1.1.3",
     "@codemod-utils/ember-cli-string": "^1.1.2",
     "@codemod-utils/files": "^2.0.2",


### PR DESCRIPTION
## Background

In #118, I had recorded the latest version of `@codemod-utils/ast-template` to be `1.1.3`, when it should have been `1.1.2`.
