### PR TITLE
Extracted getPackageRoots()

### DIFF
--- a/.changeset/slow-lizards-check.md
+++ b/.changeset/slow-lizards-check.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/files": minor
+---
+
+Extracted getPackageRoots()

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -161,6 +161,33 @@ const filePaths = findFiles([
 </details>
 
 
+### getPackageRoots
+
+Returns the roots of all packages in a project.
+
+<details>
+
+<summary>Example</summary>
+
+Analyze each package by reading `package.json`.
+
+```ts
+import { readPackageJson } from '@codemod-utils/json';
+
+const packageRoots = getPackageRoots({
+  projectRoot,
+});
+
+packageRoots.forEach((packageRoot) => {
+  const packageJson = readPackageJson({ projectRoot: packageRoot });
+
+  // ...
+});
+```
+
+</details>
+
+
 ### mapFilePaths
 
 Creates a mapping of file paths, which can then be passed to [`copyFiles`](#copyfiles) or [`moveFiles`](#movefiles). 

--- a/packages/files/src/files/get-package-roots.ts
+++ b/packages/files/src/files/get-package-roots.ts
@@ -4,6 +4,31 @@ import type { Options } from '../types/index.js';
 import { findFiles } from './find-files.js';
 import { parseFilePath } from './parse-file-path.js';
 
+/**
+ * Returns the roots of all packages in a project.
+ *
+ * @param options
+ *
+ * An object with `projectRoot`.
+ *
+ * @example
+ *
+ * Analyze each package by reading `package.json`.
+ *
+ * ```ts
+ * import { readPackageJson } from '@codemod-utils/json';
+ *
+ * const packageRoots = getPackageRoots({
+ *   projectRoot,
+ * });
+ *
+ * packageRoots.forEach((packageRoot) => {
+ *   const packageJson = readPackageJson({ projectRoot: packageRoot });
+ *
+ *   // ...
+ * });
+ * ```
+ */
 export function getPackageRoots(
   options: Options & {
     projectRoot: string;

--- a/packages/files/src/files/get-package-roots.ts
+++ b/packages/files/src/files/get-package-roots.ts
@@ -1,0 +1,33 @@
+import { join } from 'node:path';
+
+import type { Options } from '../types/index.js';
+import { findFiles } from './find-files.js';
+import { parseFilePath } from './parse-file-path.js';
+
+export function getPackageRoots(
+  options: Options & {
+    projectRoot: string;
+  },
+): string[] {
+  const { projectRoot } = options;
+
+  const filePaths = findFiles('**/package.json', {
+    ignoreList: ['**/{dist,node_modules}/**/*'],
+    projectRoot,
+  });
+
+  const packageRoots = filePaths.map((filePath) => {
+    const { dir } = parseFilePath(filePath);
+
+    return join(projectRoot, dir);
+  });
+
+  const isMonorepo = packageRoots.length > 1;
+
+  if (isMonorepo) {
+    // Exclude the workspace root
+    return packageRoots.filter((packageRoot) => packageRoot !== projectRoot);
+  }
+
+  return packageRoots;
+}

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -2,6 +2,7 @@ export * from './files/copy-files.js';
 export * from './files/create-directory.js';
 export * from './files/create-files.js';
 export * from './files/find-files.js';
+export * from './files/get-package-roots.js';
 export * from './files/map-file-paths.js';
 export * from './files/move-files.js';
 export * from './files/parse-file-path.js';

--- a/packages/files/tests/files/get-package-roots/base-case.test.ts
+++ b/packages/files/tests/files/get-package-roots/base-case.test.ts
@@ -1,0 +1,18 @@
+import { assert, loadFixture, test } from '@codemod-utils/tests';
+
+import { getPackageRoots } from '../../../src/index.js';
+import { codemodOptions, options } from '../../shared-test-setups/index.js';
+
+test('files | get-package-roots > base case', function () {
+  const inputProject = {
+    'package.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  const packageRoots = getPackageRoots({
+    projectRoot: options.projectRoot,
+  });
+
+  assert.deepStrictEqual(packageRoots, ['tmp/test-project']);
+});

--- a/packages/files/tests/files/get-package-roots/edge-case-file-name-is-incorrect.test.ts
+++ b/packages/files/tests/files/get-package-roots/edge-case-file-name-is-incorrect.test.ts
@@ -1,0 +1,20 @@
+import { assert, loadFixture, test } from '@codemod-utils/tests';
+
+import { getPackageRoots } from '../../../src/index.js';
+import { codemodOptions, options } from '../../shared-test-setups/index.js';
+
+test('files | get-package-roots > edge case (file name is incorrect)', function () {
+  const inputProject = {
+    packagejson: '',
+    'package.json5': '',
+    'somepackage.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  const packageRoots = getPackageRoots({
+    projectRoot: options.projectRoot,
+  });
+
+  assert.deepStrictEqual(packageRoots, []);
+});

--- a/packages/files/tests/files/get-package-roots/edge-case-no-packages.test.ts
+++ b/packages/files/tests/files/get-package-roots/edge-case-no-packages.test.ts
@@ -1,0 +1,16 @@
+import { assert, loadFixture, test } from '@codemod-utils/tests';
+
+import { getPackageRoots } from '../../../src/index.js';
+import { codemodOptions, options } from '../../shared-test-setups/index.js';
+
+test('files | get-package-roots > edge case (no packages)', function () {
+  const inputProject = {};
+
+  loadFixture(inputProject, codemodOptions);
+
+  const packageRoots = getPackageRoots({
+    projectRoot: options.projectRoot,
+  });
+
+  assert.deepStrictEqual(packageRoots, []);
+});

--- a/packages/files/tests/files/get-package-roots/monorepo.test.ts
+++ b/packages/files/tests/files/get-package-roots/monorepo.test.ts
@@ -1,0 +1,43 @@
+import { assert, loadFixture, test } from '@codemod-utils/tests';
+
+import { getPackageRoots } from '../../../src/index.js';
+import { codemodOptions, options } from '../../shared-test-setups/index.js';
+
+test('files | get-package-roots > monorepo', function () {
+  const inputProject = {
+    'docs-app': {
+      'package.json': '',
+    },
+    packages: {
+      'my-folder': {
+        'my-package-1': {
+          'package.json': '',
+        },
+      },
+      'my-package-2': {
+        'package.json': '',
+      },
+      'my-package-3': {
+        'package.json': '',
+      },
+    },
+    'test-app': {
+      'package.json': '',
+    },
+    'package.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  const packageRoots = getPackageRoots({
+    projectRoot: options.projectRoot,
+  });
+
+  assert.deepStrictEqual(packageRoots, [
+    'tmp/test-project/docs-app',
+    'tmp/test-project/packages/my-folder/my-package-1',
+    'tmp/test-project/packages/my-package-2',
+    'tmp/test-project/packages/my-package-3',
+    'tmp/test-project/test-app',
+  ]);
+});


### PR DESCRIPTION
## Background

This utility method is duplicated in a few codemods. Here are some public ones:

- [`analyze-ember-project-dependencies`](https://github.com/ijlee2/embroider-toolbox/blob/0.15.0/packages/analyze-ember-project-dependencies/src/steps/analyze-project/get-package-roots.ts#L7-L25)
- [`codemod-generate-release-notes`](https://github.com/Ajanth/codemod-generate-release-notes/blob/1.0.2/src/steps/get-latest-versions.ts#L62-L75)
- [`update-workspace-root-version`](https://github.com/ijlee2/update-workspace-root-version/blob/1.0.3/src/steps/get-package-versions.ts#L9-L27)

By extracting the method to `@codemod-utils/files`, we can ensure its correctness with tests and may allow more codemods to be written.
