### PR TITLE
Provide type assertions for validatePackageJson

### DIFF
--- a/.changeset/clever-dodos-sleep.md
+++ b/.changeset/clever-dodos-sleep.md
@@ -1,5 +1,5 @@
 ---
-"@codemod-utils/json": patch
+"@codemod-utils/json": minor
 ---
 
 Provide typescript assertions as to the non-null name and version properties of packages with validatePackageJson.

--- a/packages/json/README.md
+++ b/packages/json/README.md
@@ -4,9 +4,11 @@
 
 _Utilities for handling JSON_
 
+
 ## What is it?
 
 `@codemod-utils/json` helps you update files like `package.json` and `tsconfig.json`.
+
 
 ## API
 
@@ -14,7 +16,8 @@ _Utilities for handling JSON_
 
 `convertToMap()` converts an object to a Map, while `convertToObject()` converts the Map back to an object. Use these two utilities to update JSONs.
 
-> [!NOTE] > `convertToObject()` creates an object with keys in alphabetical order.
+> [!NOTE]
+> `convertToObject()` creates an object with keys in alphabetical order.
 
 <details>
 
@@ -23,20 +26,20 @@ _Utilities for handling JSON_
 Remove dependencies (if they exist) from `package.json`.
 
 ```ts
-const dependencies = convertToMap(packageJson["dependencies"]);
+const dependencies = convertToMap(packageJson['dependencies']);
 
 const packagesToDelete = [
-  "@embroider/macros",
-  "ember-auto-import",
-  "ember-cli-babel",
-  "ember-cli-htmlbars",
+  '@embroider/macros',
+  'ember-auto-import',
+  'ember-cli-babel',
+  'ember-cli-htmlbars',
 ];
 
 packagesToDelete.forEach((packageName) => {
   dependencies.delete(packageName);
 });
 
-packageJson["dependencies"] = convertToObject(dependencies);
+packageJson['dependencies'] = convertToObject(dependencies);
 ```
 
 </details>
@@ -48,24 +51,26 @@ packageJson["dependencies"] = convertToObject(dependencies);
 Configure `tsconfig.json` in an Ember app.
 
 ```ts
-const compilerOptions = convertToMap(tsConfigJson["compilerOptions"]);
+const compilerOptions = convertToMap(tsConfigJson['compilerOptions']);
 
-compilerOptions.set("paths", {
-  [`${appName}/tests/*`]: ["tests/*"],
-  [`${appName}/*`]: ["app/*"],
-  "*": ["types/*"],
+compilerOptions.set('paths', {
+  [`${appName}/tests/*`]: ['tests/*'],
+  [`${appName}/*`]: ['app/*'],
+  '*': ['types/*'],
 });
 
-tsConfigJson["compilerOptions"] = convertToObject(compilerOptions);
+tsConfigJson['compilerOptions'] = convertToObject(compilerOptions);
 ```
 
 </details>
+
 
 ### readPackageJson
 
 Reads `package.json` and returns the parsed JSON.
 
-> [!NOTE] > `readPackageJson()` checks that `package.json` exists and is a valid JSON.
+> [!NOTE]
+> `readPackageJson()` checks that `package.json` exists and is a valid JSON.
 
 <details>
 
@@ -74,7 +79,7 @@ Reads `package.json` and returns the parsed JSON.
 Check if the project, against which the codemod is run, has `typescript` as a dependency.
 
 ```ts
-import { readPackageJson } from "@codemod-utils/json";
+import { readPackageJson } from '@codemod-utils/json';
 
 const { dependencies, devDependencies } = readPackageJson({
   projectRoot,
@@ -85,42 +90,43 @@ const projectDependencies = new Map([
   ...Object.entries(devDependencies ?? {}),
 ]);
 
-const hasTypeScript = projectDependencies.has("typescript");
+const hasTypeScript = projectDependencies.has('typescript');
 ```
 
 </details>
 
+
 ### validatePackageJson
 
-Check if the fields `name` and `version` exist, in the sense that their values are a non-empty string.
-
-When used with typescript, this will provide type-checking such that the usage of both variables no longer requires a non-null assertion operator `!` for statically-analyzable code after the function call.
+(Type-)Checks that the fields `name` and `version` exist, in the sense that their values are a non-empty string.
 
 <details>
 
 <summary>Example</summary>
 
 ```js
-import { readPackageJson, validatePackageJson } from "@codemod-utils/json";
+import { readPackageJson, validatePackageJson } from '@codemod-utils/json';
 
-const packageJson = readPackageJson({
-  projectRoot,
-});
+const packageJson = readPackageJson({ projectRoot });
 
 validatePackageJson(packageJson);
 
+// Both guaranteed to be `string` (not `undefined`)
 const { name, version } = packageJson;
 ```
 
 </details>
 
+
 ## Compatibility
 
 - Node.js v18 or above
 
+
 ## Contributing
 
 See the [Contributing](../../CONTRIBUTING.md) guide for details.
+
 
 ## License
 

--- a/packages/json/src/json/validate-package-json.ts
+++ b/packages/json/src/json/validate-package-json.ts
@@ -1,8 +1,8 @@
 import type { PackageJson, ValidatedPackageJson } from '../types/index.js';
 
 /**
- * Check if the fields `name` and `version` exist, in the sense that
- * their values are a non-empty string.
+ * (Type-)Checks that the fields `name` and `version` exist, in the
+ * sense that their values are a non-empty string.
  *
  * @param packageJson
  *
@@ -11,12 +11,11 @@ import type { PackageJson, ValidatedPackageJson } from '../types/index.js';
  * @example
  *
  * ```ts
- * const packageJson = readPackageJson({
- *   projectRoot,
- * });
+ * const packageJson = readPackageJson({ projectRoot });
  *
  * validatePackageJson(packageJson);
  *
+ * // Both guaranteed to be `string` (not `undefined`)
  * const { name, version } = packageJson;
  * ```
  */

--- a/packages/json/src/types/index.ts
+++ b/packages/json/src/types/index.ts
@@ -5,7 +5,7 @@ type Options = {
   projectRoot: string;
 };
 
-export type { Options, PackageJson, TsConfigJson };
-
-export type ValidatedPackageJson = PackageJson &
+type ValidatedPackageJson = PackageJson &
   Required<Pick<PackageJson, 'name' | 'version'>>;
+
+export type { Options, PackageJson, TsConfigJson, ValidatedPackageJson };


### PR DESCRIPTION
I was reviewing this package for an upcoming use and noticed the caveat about non-null assertions for validatePackageJson:

```
You may still need the non-null assertion operator !, to tell TypeScript that name and version are not undefined.
```

There is actually a typescript construct specifically for this sort of assertion that was introduced in Typescript version 3.7: [Assert Functions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions)

This PR adds such an assertion to `validatePackageJson` such that it should no longer be required to use non-null assertions on an object for code that follows a validatePackageJson call.  It does this by introducing a new type called `ValidatedPackageJson`.

I used a bit of creative typings to ensure that ValidatedPackageJson stays true to type-fest's PackageJson, and simply removes the optionality of the name and version properties.

```ts
const myPkg: PackageJson = getFromSomewhere();

validatePackageJson(myPkg);

// Non-null assertion no longer required.
console.log(myPkg.name.length);
```

I have tested this in my IDE with typescript 5.7.3, and it works great.

Note: Since the `assert` keyword didn't exist in Typescript prior to 3.7, this update will cause the typescript typings to run into issues with build errors (or if skipLibCheck is true, replacing it with 'any') if a consumer is using Typescript versions earlier than that.  I don't know if this project wants to consider that a breaking API change or not.  Typescript 3.7 was released in November 2019, while this project was started in 2023, so its probably unlikely to see issues arise from this.  But it's something to be aware of.