### PR TITLE
Updated .prettierignore in blueprints

### DIFF
--- a/.changeset/chubby-rats-beam.md
+++ b/.changeset/chubby-rats-beam.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/cli": patch
+---
+
+Updated .prettierignore

--- a/packages/cli/src/blueprints/.prettierignore
+++ b/packages/cli/src/blueprints/.prettierignore
@@ -8,5 +8,8 @@
 /tests/fixtures/
 !.*
 .*/
+CONTRIBUTING.md
+README.md
+pnpm-lock.yaml
 
 # specific to this package

--- a/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.prettierignore
+++ b/packages/cli/tests/fixtures/javascript-with-addons/output/ember-codemod-args-to-signature/.prettierignore
@@ -8,5 +8,8 @@
 /tests/fixtures/
 !.*
 .*/
+CONTRIBUTING.md
+README.md
+pnpm-lock.yaml
 
 # specific to this package

--- a/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.prettierignore
+++ b/packages/cli/tests/fixtures/javascript/output/ember-codemod-pod-to-octane/.prettierignore
@@ -8,5 +8,8 @@
 /tests/fixtures/
 !.*
 .*/
+CONTRIBUTING.md
+README.md
+pnpm-lock.yaml
 
 # specific to this package

--- a/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.prettierignore
+++ b/packages/cli/tests/fixtures/typescript-with-addons/output/ember-codemod-args-to-signature/.prettierignore
@@ -8,5 +8,8 @@
 /tests/fixtures/
 !.*
 .*/
+CONTRIBUTING.md
+README.md
+pnpm-lock.yaml
 
 # specific to this package

--- a/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.prettierignore
+++ b/packages/cli/tests/fixtures/typescript/output/ember-codemod-pod-to-octane/.prettierignore
@@ -8,5 +8,8 @@
 /tests/fixtures/
 !.*
 .*/
+CONTRIBUTING.md
+README.md
+pnpm-lock.yaml
 
 # specific to this package


### PR DESCRIPTION
Patches #169 based on https://github.com/ijlee2/update-workspace-root-version/pull/19.