### PR TITLE
Created @codemod-utils/ast-template-tag

### DIFF
--- a/.changeset/ninety-plums-wear.md
+++ b/.changeset/ninety-plums-wear.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/ast-template-tag": minor
+---
+
+Created @codemod-utils/ast-template-tag

--- a/packages/ast/template-tag/.npmignore
+++ b/packages/ast/template-tag/.npmignore
@@ -1,0 +1,19 @@
+# compiled output
+/tmp/
+
+# dependencies
+/node_modules/
+
+# misc
+/.DS_Store
+/.env*
+/.eslintcache
+/.git/
+/.github/
+/.gitignore
+/.pnpm-debug.log
+/.prettierignore
+/build.sh
+/eslint.config.mjs
+/prettier.config.mjs
+/tests/

--- a/packages/ast/template-tag/.prettierignore
+++ b/packages/ast/template-tag/.prettierignore
@@ -1,0 +1,11 @@
+# compiled output
+/dist/
+/dist-for-testing/
+/tmp/
+ 
+# misc
+!.*
+.*/
+
+# specific to this package
+README.md

--- a/packages/ast/template-tag/CHANGELOG.md
+++ b/packages/ast/template-tag/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog for @codemod-utils/ast-template-tag

--- a/packages/ast/template-tag/LICENSE.md
+++ b/packages/ast/template-tag/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2025 Isaac J. Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/ast/template-tag/README.md
+++ b/packages/ast/template-tag/README.md
@@ -5,6 +5,194 @@
 _Utilities for handling `*.{gjs,gts}` files_
 
 
+## What is it?
+
+`@codemod-utils/ast-template-tag` uses [`content-tag`](https://github.com/embroider-build/content-tag) to help you parse and transform `*.{gjs,gts}` files.
+
+```ts
+import { updateJavaScript } from '@codemod-utils/ast-template-tag';
+
+// Reuse a method that can update `*.{js,ts}` files
+function transform(file: string): string {
+  // ...
+}
+
+const newFile = updateJavaScript(oldFile, transform);
+```
+
+```ts
+import { updateTemplates } from '@codemod-utils/ast-template-tag';
+
+// Reuse a method that can update `*.hbs` files
+function transform(file: string): string {
+  // ...
+}
+
+const newFile = updateTemplates(oldFile, transform);
+```
+
+## API
+
+### preprocess
+
+Processes a file with `<template>` tags into things that work with existing methods or libraries.
+
+⚠️ Likely, you won't need this method but [`updateJavaScript`](#updatejavascript) instead.
+
+<details>
+
+<summary>Example</summary>
+
+Analyze the JavaScript part of the file.
+
+```ts
+const { javascript } = preprocess(file);
+
+// Some method that checks `*.{js,ts}` files
+analyze(javascript);
+```
+
+</details>
+
+<details>
+
+<summary>Example</summary>
+
+Count the number of lines inside `<template>` tags.
+
+```ts
+const { templateTags } = preprocess(file);
+
+let numOfLines = 0;
+
+templateTags.forEach(({ contents }) => {
+  numOfLines += contents.trim().split('\n').length;
+});
+```
+
+</details>
+
+
+### replaceTemplate
+
+Replaces the template of a particular `<template>` tag.
+
+⚠️ Likely, you won't need this method but [`updateTemplates`](#updatetemplates) instead.
+
+<details>
+
+<summary>Example</summary>
+
+Update the template in each tag.
+
+```ts
+const { templateTags } = preprocess(file);
+
+templateTags.reverse().forEach(({ contents, range }) => {
+  // Some method that can update `*.hbs` files
+  const template = transform(contents);
+
+  file = replaceTemplate(file, { range, template });
+});
+```
+
+</details>
+
+
+### updateJavaScript
+
+Updates the JavaScript part of a file. Leaves the `<template>` tags alone.
+
+<details>
+
+<summary>Example</summary>
+
+Reuse a method that can update `*.{js,ts}` files.
+
+```ts
+function transform(file: string): string {
+  // ...
+}
+
+const newFile = updateJavaScript(oldFile, transform);
+```
+
+</details>
+
+<details>
+
+<summary>Example</summary>
+
+Provide data when updating file.
+
+```ts
+type Data = {
+  isTypeScript: boolean;
+};
+
+function transform(file: string, data: Data): string {
+  // ...
+}
+
+const data = {
+  isTypeScript: filePath.endsWith('.gts'),
+};
+
+const newFile = updateJavaScript(oldFile, (file) => {
+  return transform(file, data);
+});
+```
+
+</details>
+
+
+### updateTemplates
+
+Updates the `<template>` tags in a file. Leaves the JavaScript part alone.
+
+<details>
+
+<summary>Example</summary>
+
+Reuse a method that can update `*.hbs` files.
+
+```ts
+function transform(file: string): string {
+  // ...
+}
+
+const newFile = updateTemplates(oldFile, transform);
+```
+
+</details>
+
+<details>
+
+<summary>Example</summary>
+
+Provide data when updating file.
+
+```ts
+type Data = {
+  isTypeScript: boolean;
+};
+
+function transform(file: string, data: Data): string {
+  // ...
+}
+
+const data = {
+  isTypeScript: filePath.endsWith('.gts'),
+};
+
+const newFile = updateTemplates(oldFile, (file) => {
+  return transform(file, data);
+});
+```
+
+</details>
+
+
 ## Compatibility
 
 - Node.js v20 or above

--- a/packages/ast/template-tag/README.md
+++ b/packages/ast/template-tag/README.md
@@ -1,0 +1,20 @@
+[![This project uses GitHub Actions for continuous integration.](https://github.com/ijlee2/codemod-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/ijlee2/codemod-utils/actions/workflows/ci.yml)
+
+# @codemod-utils/ast-ast-template-tag
+
+_Utilities for handling `*.{gjs,gts}` files_
+
+
+## Compatibility
+
+- Node.js v20 or above
+
+
+## Contributing
+
+See the [Contributing](../../../CONTRIBUTING.md) guide for details.
+
+
+## License
+
+This project is licensed under the [MIT License](LICENSE.md).

--- a/packages/ast/template-tag/build.sh
+++ b/packages/ast/template-tag/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+ENVIRONMENT=$1
+
+if [ $ENVIRONMENT = "--production" ]
+then
+  # Clean slate
+  rm -rf "dist"
+
+  # Compile TypeScript
+  tsc --project "tsconfig.build.json"
+
+  echo "SUCCESS: Built dist.\n"
+
+elif [ $ENVIRONMENT = "--test" ]
+then
+  # Clean slate
+  rm -rf "dist-for-testing"
+
+  # Compile TypeScript
+  tsc --project "tsconfig.json"
+
+  echo "SUCCESS: Built dist-for-testing.\n"
+
+fi

--- a/packages/ast/template-tag/eslint.config.mjs
+++ b/packages/ast/template-tag/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@shared-configs/eslint-config-node/typescript';

--- a/packages/ast/template-tag/package.json
+++ b/packages/ast/template-tag/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@codemod-utils/ast-template-tag",
+  "version": "0.0.0",
+  "description": "Utilities for handling *.{gjs,gts} files",
+  "keywords": [
+    "codemod",
+    "ember-codemod"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:ijlee2/codemod-utils.git"
+  },
+  "license": "MIT",
+  "author": "Isaac J. Lee",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*"
+      ]
+    }
+  },
+  "directories": {
+    "test": "tests"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "./build.sh --production",
+    "format": "prettier . --cache --write",
+    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\" && pnpm format",
+    "lint:format": "prettier . --cache --check",
+    "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix",
+    "lint:types": "tsc --noEmit",
+    "test": "./build.sh --test && mt dist-for-testing --quiet"
+  },
+  "dependencies": {
+    "content-tag": "^4.0.0"
+  },
+  "devDependencies": {
+    "@codemod-utils/ast-javascript": "workspace:*",
+    "@codemod-utils/ast-template": "workspace:*",
+    "@codemod-utils/tests": "workspace:*",
+    "@shared-configs/eslint-config-node": "workspace:*",
+    "@shared-configs/prettier": "workspace:*",
+    "@shared-configs/typescript": "workspace:*",
+    "@sondr3/minitest": "^0.1.2",
+    "@types/node": "^20.19.13",
+    "concurrently": "^9.2.1",
+    "eslint": "^9.34.0",
+    "prettier": "^3.6.2",
+    "typescript": "^5.9.2"
+  },
+  "engines": {
+    "node": "20.* || >= 22"
+  }
+}

--- a/packages/ast/template-tag/prettier.config.mjs
+++ b/packages/ast/template-tag/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@shared-configs/prettier/node';

--- a/packages/ast/template-tag/src/index.ts
+++ b/packages/ast/template-tag/src/index.ts
@@ -1,0 +1,4 @@
+export * from './preprocess.js';
+export * from './replace-template.js';
+export * from './update-javascript.js';
+export * from './update-templates.js';

--- a/packages/ast/template-tag/src/preprocess.ts
+++ b/packages/ast/template-tag/src/preprocess.ts
@@ -2,6 +2,44 @@ import { type Parsed as TemplateTag, Preprocessor } from 'content-tag';
 
 const preprocessor = new Preprocessor();
 
+/**
+ * Processes a file with `<template>` tags into things that work
+ * with existing methods or libraries.
+ *
+ * @param file
+ *
+ * A `*.{gjs,gts}` file.
+ *
+ * @return
+ *
+ * An object with `javascript` (code in standard JavaScript) and
+ * `templateTags` (a sorted array that tracks tag locations).
+ *
+ * @example
+ *
+ * Analyze the JavaScript part of the file.
+ *
+ * ```ts
+ * const { javascript } = preprocess(file);
+ *
+ * // Some method that checks `*.{js,ts}` files
+ * analyze(javascript);
+ * ```
+ *
+ * @example
+ *
+ * Count the number of lines inside `<template>` tags.
+ *
+ * ```ts
+ * const { templateTags } = preprocess(file);
+ *
+ * let numOfLines = 0;
+ *
+ * templateTags.forEach(({ contents }) => {
+ *   numOfLines += contents.trim().split('\n').length;
+ * });
+ * ```
+ */
 export function preprocess(file: string): {
   javascript: string;
   templateTags: TemplateTag[];

--- a/packages/ast/template-tag/src/preprocess.ts
+++ b/packages/ast/template-tag/src/preprocess.ts
@@ -1,0 +1,16 @@
+import { type Parsed as TemplateTag, Preprocessor } from 'content-tag';
+
+const preprocessor = new Preprocessor();
+
+export function preprocess(file: string): {
+  javascript: string;
+  templateTags: TemplateTag[];
+} {
+  const javascript = preprocessor.process(file).code;
+  const templateTags = preprocessor.parse(file);
+
+  return {
+    javascript,
+    templateTags,
+  };
+}

--- a/packages/ast/template-tag/src/replace-template.ts
+++ b/packages/ast/template-tag/src/replace-template.ts
@@ -23,6 +23,37 @@ function sliceByteRange(
   return buffer.slice(indexStart, indexEnd).toString();
 }
 
+/**
+ * Replaces the template of a particular `<template>` tag.
+ *
+ * @param file
+ *
+ * A `*.{gjs,gts}` file.
+ *
+ * @param data
+ *
+ * An object with `range` (tag location) and `template` (what to
+ * replace with).
+ *
+ * @return
+ *
+ * The resulting file.
+ *
+ * @example
+ *
+ * Update the template in each tag.
+ *
+ * ```ts
+ * const { templateTags } = preprocess(file);
+ *
+ * templateTags.reverse().forEach(({ contents, range }) => {
+ *   // Some method that can update `*.hbs` files
+ *   const template = transform(contents);
+ *
+ *   file = replaceTemplate(file, { range, template });
+ * });
+ * ```
+ */
 export function replaceTemplate(
   file: string,
   data: {

--- a/packages/ast/template-tag/src/replace-template.ts
+++ b/packages/ast/template-tag/src/replace-template.ts
@@ -1,0 +1,42 @@
+import type { Range } from 'content-tag';
+
+const BufferMap = new Map<string, Buffer>();
+
+function getBuffer(str: string): Buffer {
+  let buffer = BufferMap.get(str);
+
+  if (!buffer) {
+    buffer = Buffer.from(str);
+    BufferMap.set(str, buffer);
+  }
+
+  return buffer;
+}
+
+function sliceByteRange(
+  str: string,
+  indexStart: number,
+  indexEnd?: number,
+): string {
+  const buffer = getBuffer(str);
+
+  return buffer.slice(indexStart, indexEnd).toString();
+}
+
+export function replaceTemplate(
+  file: string,
+  data: {
+    range: Range;
+    template: string;
+  },
+): string {
+  const { range, template } = data;
+
+  return [
+    sliceByteRange(file, 0, range.startByte),
+    '<template>',
+    template,
+    '</template>',
+    sliceByteRange(file, range.endByte, undefined),
+  ].join('');
+}

--- a/packages/ast/template-tag/src/update-javascript.ts
+++ b/packages/ast/template-tag/src/update-javascript.ts
@@ -36,6 +36,56 @@ function unmarkTemplateTags(file: string): string {
     .join('\n');
 }
 
+/**
+ * Updates the JavaScript part of a file. Leaves the `<template>`
+ * tags alone.
+ *
+ * @param file
+ *
+ * A `*.{gjs,gts}` file.
+ *
+ * @param update
+ *
+ * A method that describes how to update code.
+ *
+ * @return
+ *
+ * The resulting file.
+ *
+ * @example
+ *
+ * Reuse a method that can update `*.{js,ts}` files.
+ *
+ * ```ts
+ * function transform(file: string): string {
+ *   // ...
+ * }
+ *
+ * const newFile = updateJavaScript(oldFile, transform);
+ * ```
+ *
+ * @example
+ *
+ * Provide data when updating file.
+ *
+ * ```ts
+ * type Data = {
+ *   isTypeScript: boolean;
+ * };
+ *
+ * function transform(file: string, data: Data): string {
+ *   // ...
+ * }
+ *
+ * const data = {
+ *   isTypeScript: filePath.endsWith('.gts'),
+ * };
+ *
+ * const newFile = updateJavaScript(oldFile, (file) => {
+ *   return transform(file, data);
+ * });
+ * ```
+ */
 export function updateJavaScript(
   file: string,
   update: (code: string) => string,

--- a/packages/ast/template-tag/src/update-javascript.ts
+++ b/packages/ast/template-tag/src/update-javascript.ts
@@ -1,0 +1,46 @@
+const MARKER = 'template_fd9b2463e5f141cfb5666b64daa1f11a';
+
+function markTemplateTags(file: string): string {
+  const lines = file.split('\n');
+
+  return lines
+    .reduce<string[]>((accumulator, line) => {
+      if (line.includes('<template>')) {
+        accumulator.push(`/* ${MARKER}`);
+      }
+
+      accumulator.push(line);
+
+      if (line.includes('</template>')) {
+        accumulator.push(`${MARKER} */`);
+      }
+
+      return accumulator;
+    }, [])
+    .join('\n');
+}
+
+function unmarkTemplateTags(file: string): string {
+  const lines = file.split('\n');
+
+  return lines
+    .reduce<string[]>((accumulator, line) => {
+      if (line.includes(`/* ${MARKER}`) || line.includes(`${MARKER} */`)) {
+        return accumulator;
+      }
+
+      accumulator.push(line);
+
+      return accumulator;
+    }, [])
+    .join('\n');
+}
+
+export function updateJavaScript(
+  file: string,
+  update: (code: string) => string,
+): string {
+  file = update(markTemplateTags(file));
+
+  return unmarkTemplateTags(file);
+}

--- a/packages/ast/template-tag/src/update-templates.ts
+++ b/packages/ast/template-tag/src/update-templates.ts
@@ -1,0 +1,17 @@
+import { preprocess } from './preprocess.js';
+import { replaceTemplate } from './replace-template.js';
+
+export function updateTemplates(
+  file: string,
+  update: (code: string) => string,
+): string {
+  const { templateTags } = preprocess(file);
+
+  templateTags.reverse().forEach(({ contents, range }) => {
+    const template = update(contents);
+
+    file = replaceTemplate(file, { range, template });
+  });
+
+  return file;
+}

--- a/packages/ast/template-tag/src/update-templates.ts
+++ b/packages/ast/template-tag/src/update-templates.ts
@@ -1,6 +1,56 @@
 import { preprocess } from './preprocess.js';
 import { replaceTemplate } from './replace-template.js';
 
+/**
+ * Updates the `<template>` tags in a file. Leaves the JavaScript
+ * part alone.
+ *
+ * @param file
+ *
+ * A `*.{gjs,gts}` file.
+ *
+ * @param update
+ *
+ * A method that describes how to update code.
+ *
+ * @return
+ *
+ * The resulting file.
+ *
+ * @example
+ *
+ * Reuse a method that can update `*.hbs` files.
+ *
+ * ```ts
+ * function transform(file: string): string {
+ *   // ...
+ * }
+ *
+ * const newFile = updateTemplates(oldFile, transform);
+ * ```
+ *
+ * @example
+ *
+ * Provide data when updating file.
+ *
+ * ```ts
+ * type Data = {
+ *   isTypeScript: boolean;
+ * };
+ *
+ * function transform(file: string, data: Data): string {
+ *   // ...
+ * }
+ *
+ * const data = {
+ *   isTypeScript: filePath.endsWith('.gts'),
+ * };
+ *
+ * const newFile = updateTemplates(oldFile, (file) => {
+ *   return transform(file, data);
+ * });
+ * ```
+ */
 export function updateTemplates(
   file: string,
   update: (code: string) => string,

--- a/packages/ast/template-tag/tests/helpers/update-javascript.ts
+++ b/packages/ast/template-tag/tests/helpers/update-javascript.ts
@@ -1,0 +1,43 @@
+import { AST } from '@codemod-utils/ast-javascript';
+
+type Data = {
+  getters: Set<string>;
+};
+
+export const data: Data = {
+  getters: new Set(['timestamp']),
+};
+
+export function renameGetters(file: string, data: Data): string {
+  const traverse = AST.traverse(true);
+
+  const ast = traverse(file, {
+    visitClassMethod(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (node.value.kind !== 'get') {
+        return false;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const getterName = node.value.key.name as string;
+
+      if (!data.getters.has(getterName)) {
+        return false;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      node.value.comments = [
+        AST.builders.commentLine(' Assigned new name'),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        ...node.value.comments,
+      ];
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      node.value.key.name = `__${getterName}`;
+
+      return false;
+    },
+  });
+
+  return AST.print(ast);
+}

--- a/packages/ast/template-tag/tests/helpers/update-templates.ts
+++ b/packages/ast/template-tag/tests/helpers/update-templates.ts
@@ -1,0 +1,17 @@
+import { AST } from '@codemod-utils/ast-template';
+
+export function removeClassAttribute(file: string): string {
+  const traverse = AST.traverse();
+
+  const ast = traverse(file, {
+    AttrNode(node) {
+      if (node.name !== 'class') {
+        return;
+      }
+
+      return null;
+    },
+  });
+
+  return AST.print(ast);
+}

--- a/packages/ast/template-tag/tests/preprocess/base-case.test.ts
+++ b/packages/ast/template-tag/tests/preprocess/base-case.test.ts
@@ -1,0 +1,54 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { preprocess } from '../../src/index.js';
+
+test('preprocess > base case', function () {
+  const oldFile = [`<template></template>;`, ``].join('\n');
+
+  const { javascript, templateTags } = preprocess(oldFile);
+
+  assert.strictEqual(
+    javascript,
+    [
+      `import { template as template_fd9b2463e5f141cfb5666b64daa1f11a } from "@ember/template-compiler";`,
+      `export default template_fd9b2463e5f141cfb5666b64daa1f11a(\`\`, {`,
+      `    eval () {`,
+      `        return eval(arguments[0]);`,
+      `    }`,
+      `});`,
+      ``,
+    ].join('\n'),
+  );
+
+  assert.deepStrictEqual(templateTags, [
+    {
+      contentRange: {
+        endByte: 10,
+        endChar: 10,
+        startByte: 10,
+        startChar: 10,
+      },
+      contents: '',
+      endRange: {
+        endByte: 21,
+        endChar: 21,
+        startByte: 10,
+        startChar: 10,
+      },
+      range: {
+        endByte: 21,
+        endChar: 21,
+        startByte: 0,
+        startChar: 0,
+      },
+      startRange: {
+        endByte: 10,
+        endChar: 10,
+        startByte: 0,
+        startChar: 0,
+      },
+      tagName: 'template',
+      type: 'expression',
+    },
+  ]);
+});

--- a/packages/ast/template-tag/tests/preprocess/class-1.test.ts
+++ b/packages/ast/template-tag/tests/preprocess/class-1.test.ts
@@ -1,0 +1,79 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { preprocess } from '../../src/index.js';
+
+test('preprocess > class (1)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    ``,
+    `import styles from './my-component.css';`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  <template>`,
+    `    <div class={{styles.container}}>`,
+    `      Hello world!`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+    ``,
+  ].join('\n');
+
+  const { javascript, templateTags } = preprocess(oldFile);
+
+  assert.strictEqual(
+    javascript,
+    [
+      `import { template as template_fd9b2463e5f141cfb5666b64daa1f11a } from "@ember/template-compiler";`,
+      `import Component from '@glimmer/component';`,
+      `import styles from './my-component.css';`,
+      `export default class MyComponent extends Component {`,
+      `    static{`,
+      `        template_fd9b2463e5f141cfb5666b64daa1f11a(\``,
+      `    <div class={{styles.container}}>`,
+      `      Hello world!`,
+      `    </div>`,
+      `  \`, {`,
+      `            component: this,`,
+      `            eval () {`,
+      `                return eval(arguments[0]);`,
+      `            }`,
+      `        });`,
+      `    }`,
+      `}`,
+      ``,
+    ].join('\n'),
+  );
+
+  assert.deepStrictEqual(templateTags, [
+    {
+      contentRange: {
+        endByte: 222,
+        endChar: 222,
+        startByte: 152,
+        startChar: 152,
+      },
+      contents:
+        '\n    <div class={{styles.container}}>\n      Hello world!\n    </div>\n  ',
+      endRange: {
+        endByte: 233,
+        endChar: 233,
+        startByte: 222,
+        startChar: 222,
+      },
+      range: {
+        endByte: 233,
+        endChar: 233,
+        startByte: 142,
+        startChar: 142,
+      },
+      startRange: {
+        endByte: 152,
+        endChar: 152,
+        startByte: 142,
+        startChar: 142,
+      },
+      tagName: 'template',
+      type: 'class-member',
+    },
+  ]);
+});

--- a/packages/ast/template-tag/tests/preprocess/class-2.test.ts
+++ b/packages/ast/template-tag/tests/preprocess/class-2.test.ts
@@ -1,0 +1,163 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { preprocess } from '../../src/index.js';
+
+test('preprocess > class (2)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    `import { local } from 'embroider-css-modules';`,
+    ``,
+    `import styles from './example.css';`,
+    ``,
+    `const UserName = <template>`,
+    `  <div`,
+    `    class={{local styles "container" "highlight"}}`,
+    `    data-test-field="😀😀a🎉🎉"`,
+    `  >`,
+    `    {{@user.name}}`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  get timestamp(): string {`,
+    `    return 'yesterday';`,
+    `  }`,
+    ``,
+    `  <template>`,
+    `    <UserName @user={{@user}} />`,
+    ``,
+    `    <div class={{styles.container}} data-test-field="timestamp">`,
+    `      {{this.timestamp}}`,
+    ``,
+    `  <p> 😀😀😀 Hello! 🎉🎉🎉`,
+    `  </p>`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+  ].join('\n');
+
+  const { javascript, templateTags } = preprocess(oldFile);
+
+  assert.strictEqual(
+    javascript,
+    [
+      `import { template as template_fd9b2463e5f141cfb5666b64daa1f11a } from "@ember/template-compiler";`,
+      `import Component from '@glimmer/component';`,
+      `import { local } from 'embroider-css-modules';`,
+      `import styles from './example.css';`,
+      `const UserName = template_fd9b2463e5f141cfb5666b64daa1f11a(\``,
+      `  <div`,
+      `    class={{local styles "container" "highlight"}}`,
+      `    data-test-field="😀😀a🎉🎉"`,
+      `  >`,
+      `    {{@user.name}}`,
+      `  </div>`,
+      `\`, {`,
+      `    eval () {`,
+      `        return eval(arguments[0]);`,
+      `    }`,
+      `});`,
+      `export default class MyComponent extends Component {`,
+      `    get timestamp(): string {`,
+      `        return 'yesterday';`,
+      `    }`,
+      `    static{`,
+      `        template_fd9b2463e5f141cfb5666b64daa1f11a(\``,
+      `    <UserName @user={{@user}} />`,
+      ``,
+      `    <div class={{styles.container}} data-test-field="timestamp">`,
+      `      {{this.timestamp}}`,
+      ``,
+      `  <p> 😀😀😀 Hello! 🎉🎉🎉`,
+      `  </p>`,
+      `    </div>`,
+      `  \`, {`,
+      `            component: this,`,
+      `            eval () {`,
+      `                return eval(arguments[0]);`,
+      `            }`,
+      `        });`,
+      `    }`,
+      `}`,
+      ``,
+    ].join('\n'),
+  );
+
+  assert.deepStrictEqual(templateTags, [
+    {
+      contentRange: {
+        endByte: 287,
+        endChar: 275,
+        startByte: 156,
+        startChar: 156,
+      },
+      contents:
+        '\n' +
+        '  <div\n' +
+        '    class={{local styles "container" "highlight"}}\n' +
+        '    data-test-field="😀😀a🎉🎉"\n' +
+        '  >\n' +
+        '    {{@user.name}}\n' +
+        '  </div>\n',
+      endRange: {
+        endByte: 298,
+        endChar: 286,
+        startByte: 287,
+        startChar: 275,
+      },
+      range: {
+        endByte: 298,
+        endChar: 286,
+        startByte: 146,
+        startChar: 146,
+      },
+      startRange: {
+        endByte: 156,
+        endChar: 156,
+        startByte: 146,
+        startChar: 146,
+      },
+      tagName: 'template',
+      type: 'expression',
+    },
+    {
+      contentRange: {
+        endByte: 608,
+        endChar: 578,
+        startByte: 423,
+        startChar: 411,
+      },
+      contents:
+        '\n' +
+        '    <UserName @user={{@user}} />\n' +
+        '\n' +
+        '    <div class={{styles.container}} data-test-field="timestamp">\n' +
+        '      {{this.timestamp}}\n' +
+        '\n' +
+        '  <p> 😀😀😀 Hello! 🎉🎉🎉\n' +
+        '  </p>\n' +
+        '    </div>\n' +
+        '  ',
+      endRange: {
+        endByte: 619,
+        endChar: 589,
+        startByte: 608,
+        startChar: 578,
+      },
+      range: {
+        endByte: 619,
+        endChar: 589,
+        startByte: 413,
+        startChar: 401,
+      },
+      startRange: {
+        endByte: 423,
+        endChar: 411,
+        startByte: 413,
+        startChar: 401,
+      },
+      tagName: 'template',
+      type: 'class-member',
+    },
+  ]);
+});

--- a/packages/ast/template-tag/tests/preprocess/template-only-1.test.ts
+++ b/packages/ast/template-tag/tests/preprocess/template-only-1.test.ts
@@ -1,0 +1,69 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { preprocess } from '../../src/index.js';
+
+test('preprocess > template only (1)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `<template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const { javascript, templateTags } = preprocess(oldFile);
+
+  assert.strictEqual(
+    javascript,
+    [
+      `import { template as template_fd9b2463e5f141cfb5666b64daa1f11a } from "@ember/template-compiler";`,
+      `import styles from './styles.css';`,
+      `export default template_fd9b2463e5f141cfb5666b64daa1f11a(\``,
+      `  <div class={{styles.container}}>`,
+      `    Hello world!`,
+      `  </div>`,
+      `\`, {`,
+      `    eval () {`,
+      `        return eval(arguments[0]);`,
+      `    }`,
+      `});`,
+      ``,
+    ].join('\n'),
+  );
+
+  assert.deepStrictEqual(templateTags, [
+    {
+      contentRange: {
+        endByte: 108,
+        endChar: 108,
+        startByte: 46,
+        startChar: 46,
+      },
+      contents:
+        '\n  <div class={{styles.container}}>\n    Hello world!\n  </div>\n',
+      endRange: {
+        endByte: 119,
+        endChar: 119,
+        startByte: 108,
+        startChar: 108,
+      },
+      range: {
+        endByte: 119,
+        endChar: 119,
+        startByte: 36,
+        startChar: 36,
+      },
+      startRange: {
+        endByte: 46,
+        endChar: 46,
+        startByte: 36,
+        startChar: 36,
+      },
+      tagName: 'template',
+      type: 'expression',
+    },
+  ]);
+});

--- a/packages/ast/template-tag/tests/preprocess/template-only-2.test.ts
+++ b/packages/ast/template-tag/tests/preprocess/template-only-2.test.ts
@@ -1,0 +1,69 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { preprocess } from '../../src/index.js';
+
+test('preprocess > template only (2)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `export default <template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const { javascript, templateTags } = preprocess(oldFile);
+
+  assert.strictEqual(
+    javascript,
+    [
+      `import { template as template_fd9b2463e5f141cfb5666b64daa1f11a } from "@ember/template-compiler";`,
+      `import styles from './styles.css';`,
+      `export default template_fd9b2463e5f141cfb5666b64daa1f11a(\``,
+      `  <div class={{styles.container}}>`,
+      `    Hello world!`,
+      `  </div>`,
+      `\`, {`,
+      `    eval () {`,
+      `        return eval(arguments[0]);`,
+      `    }`,
+      `});`,
+      ``,
+    ].join('\n'),
+  );
+
+  assert.deepStrictEqual(templateTags, [
+    {
+      contentRange: {
+        endByte: 123,
+        endChar: 123,
+        startByte: 61,
+        startChar: 61,
+      },
+      contents:
+        '\n  <div class={{styles.container}}>\n    Hello world!\n  </div>\n',
+      endRange: {
+        endByte: 134,
+        endChar: 134,
+        startByte: 123,
+        startChar: 123,
+      },
+      range: {
+        endByte: 134,
+        endChar: 134,
+        startByte: 51,
+        startChar: 51,
+      },
+      startRange: {
+        endByte: 61,
+        endChar: 61,
+        startByte: 51,
+        startChar: 51,
+      },
+      tagName: 'template',
+      type: 'expression',
+    },
+  ]);
+});

--- a/packages/ast/template-tag/tests/replace-template/base-case.test.ts
+++ b/packages/ast/template-tag/tests/replace-template/base-case.test.ts
@@ -1,0 +1,22 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { replaceTemplate } from '../../src/index.js';
+
+test('replace-template > base case', function () {
+  const oldFile = [`<template></template>;`, ``].join('\n');
+
+  const newFile = replaceTemplate(oldFile, {
+    range: {
+      endByte: 21,
+      endChar: 21,
+      startByte: 0,
+      startChar: 0,
+    },
+    template: 'New contents',
+  });
+
+  assert.strictEqual(
+    newFile,
+    [`<template>New contents</template>;`, ``].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/replace-template/class-1.test.ts
+++ b/packages/ast/template-tag/tests/replace-template/class-1.test.ts
@@ -1,0 +1,46 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { replaceTemplate } from '../../src/index.js';
+
+test('replace-template > class (1)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    ``,
+    `import styles from './my-component.css';`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  <template>`,
+    `    <div class={{styles.container}}>`,
+    `      Hello world!`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+    ``,
+  ].join('\n');
+
+  const newFile = replaceTemplate(oldFile, {
+    range: {
+      endByte: 233,
+      endChar: 233,
+      startByte: 142,
+      startChar: 142,
+    },
+    template: '\n    New contents\n  ',
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import Component from '@glimmer/component';`,
+      ``,
+      `import styles from './my-component.css';`,
+      ``,
+      `export default class MyComponent extends Component {`,
+      `  <template>`,
+      `    New contents`,
+      `  </template>`,
+      `}`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/replace-template/class-2.test.ts
+++ b/packages/ast/template-tag/tests/replace-template/class-2.test.ts
@@ -1,0 +1,77 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { replaceTemplate } from '../../src/index.js';
+
+test('replace-template > class (2)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    `import { local } from 'embroider-css-modules';`,
+    ``,
+    `import styles from './example.css';`,
+    ``,
+    `const UserName = <template>`,
+    `  <div`,
+    `    class={{local styles "container" "highlight"}}`,
+    `    data-test-field="😀😀a🎉🎉"`,
+    `  >`,
+    `    {{@user.name}}`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  get timestamp(): string {`,
+    `    return 'yesterday';`,
+    `  }`,
+    ``,
+    `  <template>`,
+    `    <UserName @user={{@user}} />`,
+    ``,
+    `    <div class={{styles.container}} data-test-field="timestamp">`,
+    `      {{this.timestamp}}`,
+    ``,
+    `  <p> 😀😀😀 Hello! 🎉🎉🎉`,
+    `  </p>`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+  ].join('\n');
+
+  const newFile = replaceTemplate(oldFile, {
+    range: {
+      endByte: 619,
+      endChar: 589,
+      startByte: 413,
+      startChar: 401,
+    },
+    template: '\n    New contents\n  ',
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import Component from '@glimmer/component';`,
+      `import { local } from 'embroider-css-modules';`,
+      ``,
+      `import styles from './example.css';`,
+      ``,
+      `const UserName = <template>`,
+      `  <div`,
+      `    class={{local styles "container" "highlight"}}`,
+      `    data-test-field="😀😀a🎉🎉"`,
+      `  >`,
+      `    {{@user.name}}`,
+      `  </div>`,
+      `</template>;`,
+      ``,
+      `export default class MyComponent extends Component {`,
+      `  get timestamp(): string {`,
+      `    return 'yesterday';`,
+      `  }`,
+      ``,
+      `  <template>`,
+      `    New contents`,
+      `  </template>`,
+      `}`,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/replace-template/template-only-1.test.ts
+++ b/packages/ast/template-tag/tests/replace-template/template-only-1.test.ts
@@ -1,0 +1,38 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { replaceTemplate } from '../../src/index.js';
+
+test('replace-template > template-only (1)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `<template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const newFile = replaceTemplate(oldFile, {
+    range: {
+      endByte: 119,
+      endChar: 119,
+      startByte: 36,
+      startChar: 36,
+    },
+    template: '\n  New contents\n',
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import styles from './styles.css';`,
+      ``,
+      `<template>`,
+      `  New contents`,
+      `</template>;`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/replace-template/template-only-2.test.ts
+++ b/packages/ast/template-tag/tests/replace-template/template-only-2.test.ts
@@ -1,0 +1,38 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { replaceTemplate } from '../../src/index.js';
+
+test('replace-template > template-only (2)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `export default <template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const newFile = replaceTemplate(oldFile, {
+    range: {
+      endByte: 134,
+      endChar: 134,
+      startByte: 51,
+      startChar: 51,
+    },
+    template: '\n  New contents\n',
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import styles from './styles.css';`,
+      ``,
+      `export default <template>`,
+      `  New contents`,
+      `</template>;`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-javascript/base-case.test.ts
+++ b/packages/ast/template-tag/tests/update-javascript/base-case.test.ts
@@ -1,0 +1,14 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateJavaScript } from '../../src/index.js';
+import { data, renameGetters } from '../helpers/update-javascript.js';
+
+test('update-javascript > base case', function () {
+  const oldFile = [`<template></template>;`, ``].join('\n');
+
+  const newFile = updateJavaScript(oldFile, (code) => {
+    return renameGetters(code, data);
+  });
+
+  assert.strictEqual(newFile, [`<template></template>;`, ``].join('\n'));
+});

--- a/packages/ast/template-tag/tests/update-javascript/class-1.test.ts
+++ b/packages/ast/template-tag/tests/update-javascript/class-1.test.ts
@@ -1,0 +1,43 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateJavaScript } from '../../src/index.js';
+import { data, renameGetters } from '../helpers/update-javascript.js';
+
+test('update-javascript > class (1)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    ``,
+    `import styles from './my-component.css';`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  <template>`,
+    `    <div class={{styles.container}}>`,
+    `      Hello world!`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+    ``,
+  ].join('\n');
+
+  const newFile = updateJavaScript(oldFile, (code) => {
+    return renameGetters(code, data);
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import Component from '@glimmer/component';`,
+      ``,
+      `import styles from './my-component.css';`,
+      ``,
+      `export default class MyComponent extends Component {`,
+      `  <template>`,
+      `    <div class={{styles.container}}>`,
+      `      Hello world!`,
+      `    </div>`,
+      `  </template>`,
+      `}`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-javascript/class-2.test.ts
+++ b/packages/ast/template-tag/tests/update-javascript/class-2.test.ts
@@ -1,0 +1,80 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateJavaScript } from '../../src/index.js';
+import { data, renameGetters } from '../helpers/update-javascript.js';
+
+test('update-javascript > class (2)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    `import { local } from 'embroider-css-modules';`,
+    ``,
+    `import styles from './example.css';`,
+    ``,
+    `const UserName = <template>`,
+    `  <div`,
+    `    class={{local styles "container" "highlight"}}`,
+    `    data-test-field="😀😀a🎉🎉"`,
+    `  >`,
+    `    {{@user.name}}`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  get timestamp(): string {`,
+    `    return 'yesterday';`,
+    `  }`,
+    ``,
+    `  <template>`,
+    `    <UserName @user={{@user}} />`,
+    ``,
+    `    <div class={{styles.container}} data-test-field="timestamp">`,
+    `      {{this.timestamp}}`,
+    ``,
+    `  <p> 😀😀😀 Hello! 🎉🎉🎉`,
+    `  </p>`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+  ].join('\n');
+
+  const newFile = updateJavaScript(oldFile, (code) => {
+    return renameGetters(code, data);
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import Component from '@glimmer/component';`,
+      `import { local } from 'embroider-css-modules';`,
+      ``,
+      `import styles from './example.css';`,
+      ``,
+      `const UserName = <template>`,
+      `  <div`,
+      `    class={{local styles "container" "highlight"}}`,
+      `    data-test-field="😀😀a🎉🎉"`,
+      `  >`,
+      `    {{@user.name}}`,
+      `  </div>`,
+      `</template>;`,
+      ``,
+      `export default class MyComponent extends Component {`,
+      `  // Assigned new name`,
+      `  get __timestamp(): string {`,
+      `    return 'yesterday';`,
+      `  }`,
+      ``,
+      `    <template>`,
+      `      <UserName @user={{@user}} />`,
+      ``,
+      `      <div class={{styles.container}} data-test-field="timestamp">`,
+      `        {{this.timestamp}}`,
+      ``,
+      `    <p> 😀😀😀 Hello! 🎉🎉🎉`,
+      `    </p>`,
+      `      </div>`,
+      `    </template>`,
+      `}`,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-javascript/template-only-1.test.ts
+++ b/packages/ast/template-tag/tests/update-javascript/template-only-1.test.ts
@@ -1,0 +1,35 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateJavaScript } from '../../src/index.js';
+import { data, renameGetters } from '../helpers/update-javascript.js';
+
+test('update-javascript > template-only (1)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `<template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const newFile = updateJavaScript(oldFile, (code) => {
+    return renameGetters(code, data);
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import styles from './styles.css';`,
+      ``,
+      `<template>`,
+      `  <div class={{styles.container}}>`,
+      `    Hello world!`,
+      `  </div>`,
+      `</template>;`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-javascript/template-only-2.test.ts
+++ b/packages/ast/template-tag/tests/update-javascript/template-only-2.test.ts
@@ -1,0 +1,35 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateJavaScript } from '../../src/index.js';
+import { data, renameGetters } from '../helpers/update-javascript.js';
+
+test('update-javascript > template-only (2)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `export default <template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const newFile = updateJavaScript(oldFile, (code) => {
+    return renameGetters(code, data);
+  });
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import styles from './styles.css';`,
+      ``,
+      `export default <template>`,
+      `  <div class={{styles.container}}>`,
+      `    Hello world!`,
+      `  </div>`,
+      `</template>;`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-templates/base-case.test.ts
+++ b/packages/ast/template-tag/tests/update-templates/base-case.test.ts
@@ -1,0 +1,12 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateTemplates } from '../../src/index.js';
+import { removeClassAttribute } from '../helpers/update-templates.js';
+
+test('update-templates > base case', function () {
+  const oldFile = [`<template></template>;`, ``].join('\n');
+
+  const newFile = updateTemplates(oldFile, removeClassAttribute);
+
+  assert.strictEqual(newFile, [`<template></template>;`, ``].join('\n'));
+});

--- a/packages/ast/template-tag/tests/update-templates/class-1.test.ts
+++ b/packages/ast/template-tag/tests/update-templates/class-1.test.ts
@@ -1,0 +1,41 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateTemplates } from '../../src/index.js';
+import { removeClassAttribute } from '../helpers/update-templates.js';
+
+test('update-templates > class (1)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    ``,
+    `import styles from './my-component.css';`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  <template>`,
+    `    <div class={{styles.container}}>`,
+    `      Hello world!`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+    ``,
+  ].join('\n');
+
+  const newFile = updateTemplates(oldFile, removeClassAttribute);
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import Component from '@glimmer/component';`,
+      ``,
+      `import styles from './my-component.css';`,
+      ``,
+      `export default class MyComponent extends Component {`,
+      `  <template>`,
+      `    <div>`,
+      `      Hello world!`,
+      `    </div>`,
+      `  </template>`,
+      `}`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-templates/class-2.test.ts
+++ b/packages/ast/template-tag/tests/update-templates/class-2.test.ts
@@ -1,0 +1,76 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateTemplates } from '../../src/index.js';
+import { removeClassAttribute } from '../helpers/update-templates.js';
+
+test('update-templates > class (2)', function () {
+  const oldFile = [
+    `import Component from '@glimmer/component';`,
+    `import { local } from 'embroider-css-modules';`,
+    ``,
+    `import styles from './example.css';`,
+    ``,
+    `const UserName = <template>`,
+    `  <div`,
+    `    class={{local styles "container" "highlight"}}`,
+    `    data-test-field="😀😀a🎉🎉"`,
+    `  >`,
+    `    {{@user.name}}`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+    `export default class MyComponent extends Component {`,
+    `  get timestamp(): string {`,
+    `    return 'yesterday';`,
+    `  }`,
+    ``,
+    `  <template>`,
+    `    <UserName @user={{@user}} />`,
+    ``,
+    `    <div class={{styles.container}} data-test-field="timestamp">`,
+    `      {{this.timestamp}}`,
+    ``,
+    `  <p> 😀😀😀 Hello! 🎉🎉🎉`,
+    `  </p>`,
+    `    </div>`,
+    `  </template>`,
+    `}`,
+  ].join('\n');
+
+  const newFile = updateTemplates(oldFile, removeClassAttribute);
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import Component from '@glimmer/component';`,
+      `import { local } from 'embroider-css-modules';`,
+      ``,
+      `import styles from './example.css';`,
+      ``,
+      `const UserName = <template>`,
+      `  <div`,
+      `    data-test-field="😀😀a🎉🎉"`,
+      `  >`,
+      `    {{@user.name}}`,
+      `  </div>`,
+      `</template>;`,
+      ``,
+      `export default class MyComponent extends Component {`,
+      `  get timestamp(): string {`,
+      `    return 'yesterday';`,
+      `  }`,
+      ``,
+      `  <template>`,
+      `    <UserName @user={{@user}} />`,
+      ``,
+      `    <div data-test-field="timestamp">`,
+      `      {{this.timestamp}}`,
+      ``,
+      `  <p> 😀😀😀 Hello! 🎉🎉🎉`,
+      `  </p>`,
+      `    </div>`,
+      `  </template>`,
+      `}`,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-templates/template-only-1.test.ts
+++ b/packages/ast/template-tag/tests/update-templates/template-only-1.test.ts
@@ -1,0 +1,33 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateTemplates } from '../../src/index.js';
+import { removeClassAttribute } from '../helpers/update-templates.js';
+
+test('update-templates > template-only (1)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `<template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const newFile = updateTemplates(oldFile, removeClassAttribute);
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import styles from './styles.css';`,
+      ``,
+      `<template>`,
+      `  <div>`,
+      `    Hello world!`,
+      `  </div>`,
+      `</template>;`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tests/update-templates/template-only-2.test.ts
+++ b/packages/ast/template-tag/tests/update-templates/template-only-2.test.ts
@@ -1,0 +1,33 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { updateTemplates } from '../../src/index.js';
+import { removeClassAttribute } from '../helpers/update-templates.js';
+
+test('update-templates > template-only (2)', function () {
+  const oldFile = [
+    `import styles from './styles.css';`,
+    ``,
+    `export default <template>`,
+    `  <div class={{styles.container}}>`,
+    `    Hello world!`,
+    `  </div>`,
+    `</template>;`,
+    ``,
+  ].join('\n');
+
+  const newFile = updateTemplates(oldFile, removeClassAttribute);
+
+  assert.strictEqual(
+    newFile,
+    [
+      `import styles from './styles.css';`,
+      ``,
+      `export default <template>`,
+      `  <div>`,
+      `    Hello world!`,
+      `  </div>`,
+      `</template>;`,
+      ``,
+    ].join('\n'),
+  );
+});

--- a/packages/ast/template-tag/tsconfig.build.json
+++ b/packages/ast/template-tag/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shared-configs/typescript/node20",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/ast/template-tag/tsconfig.json
+++ b/packages/ast/template-tag/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shared-configs/typescript/node20",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist-for-testing"
+  },
+  "include": ["src", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,49 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  packages/ast/template-tag:
+    dependencies:
+      content-tag:
+        specifier: ^4.0.0
+        version: 4.0.0
+    devDependencies:
+      '@codemod-utils/ast-javascript':
+        specifier: workspace:*
+        version: link:../javascript
+      '@codemod-utils/ast-template':
+        specifier: workspace:*
+        version: link:../template
+      '@codemod-utils/tests':
+        specifier: workspace:*
+        version: link:../../tests
+      '@shared-configs/eslint-config-node':
+        specifier: workspace:*
+        version: link:../../../configs/eslint/node
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../../../configs/prettier
+      '@shared-configs/typescript':
+        specifier: workspace:*
+        version: link:../../../configs/typescript
+      '@sondr3/minitest':
+        specifier: ^0.1.2
+        version: 0.1.2
+      '@types/node':
+        specifier: ^20.19.13
+        version: 20.19.13
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      eslint:
+        specifier: ^9.34.0
+        version: 9.34.0
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
   packages/blueprints:
     dependencies:
       lodash:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - configs/**
   - packages/ast/javascript
   - packages/ast/template
+  - packages/ast/template-tag
   - packages/blueprints
   - packages/cli
   - packages/ember


### PR DESCRIPTION
## Background

Provides wrappers for [`content-tag`](https://github.com/embroider-build/content-tag) to meet the growing demand for `<template>` tags in Ember projects.
