### PR TITLE
Allowed v1 addons to omit the ember-addon key

### DIFF
--- a/.changeset/open-beans-end.md
+++ b/.changeset/open-beans-end.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/package-json": patch
+---
+
+Allowed v1 addons to omit the ember-addon key

--- a/packages/package-json/src/get-package-type.ts
+++ b/packages/package-json/src/get-package-type.ts
@@ -55,8 +55,8 @@ function getPackageFields(packageJson: PackageJson): {
 export function getPackageType(packageJson: PackageJson): PackageType {
   const { dependencies, emberAddon, keywords } = getPackageFields(packageJson);
 
-  if (keywords.includes('ember-addon') && emberAddon) {
-    return emberAddon['version'] === 2 ? 'v2-addon' : 'v1-addon';
+  if (keywords.includes('ember-addon')) {
+    return emberAddon?.['version'] === 2 ? 'v2-addon' : 'v1-addon';
   }
 
   if (dependencies.has('ember-source')) {

--- a/packages/package-json/tests/get-package-type/v1-addon-ember-source-is-missing.test.ts
+++ b/packages/package-json/tests/get-package-type/v1-addon-ember-source-is-missing.test.ts
@@ -2,7 +2,7 @@ import { assert, test } from '@codemod-utils/tests';
 
 import { getPackageType } from '../../src/index.js';
 
-test('get-package-type > v1-addon (ember-addon is missing)', function () {
+test('get-package-type > v1-addon', function () {
   const packageJson = {
     name: 'ember-container-query',
     version: '3.2.0',
@@ -11,11 +11,12 @@ test('get-package-type > v1-addon (ember-addon is missing)', function () {
       'ember-cli-babel': '^7.26.11',
       'ember-cli-htmlbars': '^6.1.1',
     },
-    devDependencies: {
-      'ember-source': '~4.8.0',
-    },
     ember: {
       edition: 'octane',
+    },
+    'ember-addon': {
+      configPath: 'tests/dummy/config',
+      demoURL: 'https://github.com/ijlee2/ember-container-query/',
     },
   };
 

--- a/packages/package-json/tests/get-package-type/v1-addon-version-is-1.test.ts
+++ b/packages/package-json/tests/get-package-type/v1-addon-version-is-1.test.ts
@@ -2,7 +2,7 @@ import { assert, test } from '@codemod-utils/tests';
 
 import { getPackageType } from '../../src/index.js';
 
-test('get-package-type > v1-addon (ember-addon is missing)', function () {
+test('get-package-type > v1-addon (version is 1)', function () {
   const packageJson = {
     name: 'ember-container-query',
     version: '3.2.0',
@@ -16,6 +16,9 @@ test('get-package-type > v1-addon (ember-addon is missing)', function () {
     },
     ember: {
       edition: 'octane',
+    },
+    'ember-addon': {
+      version: 1,
     },
   };
 

--- a/packages/package-json/tests/get-package-type/v2-addon-ember-source-is-missing.test.ts
+++ b/packages/package-json/tests/get-package-type/v2-addon-ember-source-is-missing.test.ts
@@ -1,0 +1,36 @@
+import { assert, test } from '@codemod-utils/tests';
+
+import { getPackageType } from '../../src/index.js';
+
+test('get-package-type > v2-addon (ember-source is missing)', function () {
+  const packageJson = {
+    name: 'ember-container-query',
+    version: '6.0.2',
+    keywords: ['ember-addon'],
+    dependencies: {
+      '@embroider/addon-shim': '^1.10.0',
+      'decorator-transforms': '^2.3.0',
+    },
+    ember: {
+      edition: 'octane',
+    },
+    'ember-addon': {
+      'app-js': {
+        './components/container-query.js':
+          './dist/_app_/components/container-query.js',
+        './helpers/aspect-ratio.js': './dist/_app_/helpers/aspect-ratio.js',
+        './helpers/height.js': './dist/_app_/helpers/height.js',
+        './helpers/width.js': './dist/_app_/helpers/width.js',
+        './modifiers/container-query.js':
+          './dist/_app_/modifiers/container-query.js',
+      },
+      main: 'addon-main.cjs',
+      type: 'addon',
+      version: 2,
+    },
+  };
+
+  const packageType = getPackageType(packageJson);
+
+  assert.strictEqual(packageType, 'v2-addon');
+});


### PR DESCRIPTION
## Background

Patches #202. I found a v1 addon that runs in an Ember app even when it hadn't specified `ember-addon`.
