### PR TITLE
Exported the type TemplateTag

### DIFF
--- a/.changeset/dull-books-hope.md
+++ b/.changeset/dull-books-hope.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/ast-template-tag": minor
+---
+
+Exported the type TemplateTag

--- a/packages/ast/template-tag/src/find-template-tags.ts
+++ b/packages/ast/template-tag/src/find-template-tags.ts
@@ -36,3 +36,5 @@ export function findTemplateTags(file: string): TemplateTag[] {
 
   return templateTags;
 }
+
+export type { TemplateTag };


### PR DESCRIPTION
## Background

This allows end-developers to provide TypeScript more accurate type information:

Before:

```ts
import { findTemplateTags } from '@codemod-utils/ast-template-tag';

type TemplateTag = ReturnType<typeof findTemplateTags>;

// The end-developer knows that only 1 `<template>` tag exists
const templateTags = findTemplateTags() as [TemplateTag];
const template = templateTags[0].contents;
```

After:

```ts
import { findTemplateTags, type TemplateTag } from '@codemod-utils/ast-template-tag';

// The end-developer knows that only 1 `<template>` tag exists
const templateTags = findTemplateTags() as [TemplateTag];
const template = templateTags[0].contents;
```