### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/better-tires-wait.md
+++ b/.changeset/better-tires-wait.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/ast-template-tag": minor
+---
+
+Fixed lint errors

--- a/packages/ast/template-tag/src/-private/content-tag/get-template.ts
+++ b/packages/ast/template-tag/src/-private/content-tag/get-template.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { MARKER } from './marker.js';
 
 export function getTemplate(expression: unknown): string | undefined {
@@ -9,14 +8,17 @@ export function getTemplate(expression: unknown): string | undefined {
 
   if (
     // @ts-expect-error: Incorrect type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expression.callee.type !== 'Identifier' ||
     // @ts-expect-error: Incorrect type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expression.callee.name !== MARKER
   ) {
     return;
   }
 
   // @ts-expect-error: Incorrect type
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const template = expression.arguments[0].quasis[0].value.raw as string;
 
   return template;

--- a/packages/ast/template-tag/src/-private/to-ecma.ts
+++ b/packages/ast/template-tag/src/-private/to-ecma.ts
@@ -12,16 +12,6 @@ type Marker = {
   };
 };
 
-function getMarker(nodeValue: unknown): Marker {
-  return {
-    // @ts-expect-error: Incorrect type
-    code: AST.print(nodeValue),
-    // @ts-expect-error: Incorrect type
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    end: nodeValue.loc.end,
-  };
-}
-
 function sortMarkers(a: Marker, b: Marker): number {
   if (a.end.line > b.end.line) {
     return -1;
@@ -49,52 +39,60 @@ export function findMarkers(file: string): Marker[] {
   const markers: Marker[] = [];
 
   traverse(code, {
-    visitCallExpression(node) {
-      const template = getTemplate(node.value);
+    visitCallExpression(path) {
+      const template = getTemplate(path.node);
 
       if (template === undefined) {
-        this.traverse(node);
+        this.traverse(path);
 
         return false;
       }
 
-      markers.push(getMarker(node.value));
+      markers.push({
+        code: AST.print(path.node),
+        // @ts-expect-error: Incorrect type
+        end: path.node.loc!.end,
+      });
 
       return false;
     },
 
-    visitExportDefaultDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const template = getTemplate(node.value.declaration);
+    visitExportDefaultDeclaration(path) {
+      const template = getTemplate(path.node.declaration);
 
       if (template === undefined) {
-        this.traverse(node);
+        this.traverse(path);
 
         return false;
       }
 
-      markers.push(getMarker(node.value));
+      markers.push({
+        code: AST.print(path.node),
+        // @ts-expect-error: Incorrect type
+        end: path.node.loc!.end,
+      });
 
       return false;
     },
 
-    visitStaticBlock(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const bodyNode = node.value.body[0];
+    visitStaticBlock(path) {
+      const bodyNode = path.node.body[0]!;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (bodyNode.type !== 'ExpressionStatement') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const template = getTemplate(bodyNode.expression);
 
       if (template === undefined) {
         return false;
       }
 
-      markers.push(getMarker(node.value));
+      markers.push({
+        code: AST.print(path.node),
+        // @ts-expect-error: Incorrect type
+        end: path.node.loc!.end,
+      });
 
       return false;
     },

--- a/packages/ast/template-tag/src/-private/to-ecma.ts
+++ b/packages/ast/template-tag/src/-private/to-ecma.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 import { getTemplate, preprocessor } from './content-tag.js';
@@ -18,6 +17,7 @@ function getMarker(nodeValue: unknown): Marker {
     // @ts-expect-error: Incorrect type
     code: AST.print(nodeValue),
     // @ts-expect-error: Incorrect type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     end: nodeValue.loc.end,
   };
 }
@@ -64,6 +64,7 @@ export function findMarkers(file: string): Marker[] {
     },
 
     visitExportDefaultDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const template = getTemplate(node.value.declaration);
 
       if (template === undefined) {
@@ -78,12 +79,15 @@ export function findMarkers(file: string): Marker[] {
     },
 
     visitStaticBlock(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const bodyNode = node.value.body[0];
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (bodyNode.type !== 'ExpressionStatement') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const template = getTemplate(bodyNode.expression);
 
       if (template === undefined) {

--- a/packages/ast/template-tag/src/-private/to-template-tag.ts
+++ b/packages/ast/template-tag/src/-private/to-template-tag.ts
@@ -10,11 +10,11 @@ export function removeMarkers(file: string): string {
   const traverse = AST.traverse(true);
 
   const ast = traverse(file, {
-    visitCallExpression(node) {
-      const template = getTemplate(node.value);
+    visitCallExpression(path) {
+      const template = getTemplate(path.node);
 
       if (template === undefined) {
-        this.traverse(node);
+        this.traverse(path);
 
         return false;
       }
@@ -22,12 +22,11 @@ export function removeMarkers(file: string): string {
       return `<template>${template}</template>`;
     },
 
-    visitExportDefaultDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const template = getTemplate(node.value.declaration);
+    visitExportDefaultDeclaration(path) {
+      const template = getTemplate(path.node.declaration);
 
       if (template === undefined) {
-        this.traverse(node);
+        this.traverse(path);
 
         return false;
       }
@@ -35,12 +34,10 @@ export function removeMarkers(file: string): string {
       return `<template>${template}</template>`;
     },
 
-    visitImportDeclaration(node) {
+    visitImportDeclaration(path) {
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.source.type !== 'StringLiteral' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.source.value !== '@ember/template-compiler'
+        path.node.source.type !== 'StringLiteral' ||
+        path.node.source.value !== '@ember/template-compiler'
       ) {
         return false;
       }
@@ -49,16 +46,13 @@ export function removeMarkers(file: string): string {
       return null;
     },
 
-    visitStaticBlock(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const bodyNode = node.value.body[0];
+    visitStaticBlock(path) {
+      const bodyNode = path.node.body[0]!;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (bodyNode.type !== 'ExpressionStatement') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const template = getTemplate(bodyNode.expression);
 
       if (template === undefined) {

--- a/packages/ast/template-tag/src/-private/to-template-tag.ts
+++ b/packages/ast/template-tag/src/-private/to-template-tag.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 import { getTemplate, MARKER } from './content-tag.js';
@@ -24,6 +23,7 @@ export function removeMarkers(file: string): string {
     },
 
     visitExportDefaultDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const template = getTemplate(node.value.declaration);
 
       if (template === undefined) {
@@ -37,7 +37,9 @@ export function removeMarkers(file: string): string {
 
     visitImportDeclaration(node) {
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.source.type !== 'StringLiteral' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.source.value !== '@ember/template-compiler'
       ) {
         return false;
@@ -48,12 +50,15 @@ export function removeMarkers(file: string): string {
     },
 
     visitStaticBlock(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const bodyNode = node.value.body[0];
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (bodyNode.type !== 'ExpressionStatement') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const template = getTemplate(bodyNode.expression);
 
       if (template === undefined) {


### PR DESCRIPTION
## Background

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
