### PR TITLE
Replaced ember-template-recast with @glimmer/syntax in documentations

### DIFF
--- a/.changeset/legal-loops-fail.md
+++ b/.changeset/legal-loops-fail.md
@@ -1,0 +1,6 @@
+---
+"@codemod-utils/ast-template": patch
+"docs-app-for-codemod-utils": patch
+---
+
+Replaced ember-template-recast with @glimmer/syntax in documentations

--- a/docs/src/docs/packages/codemod-utils-ast-template.md
+++ b/docs/src/docs/packages/codemod-utils-ast-template.md
@@ -5,7 +5,7 @@ _Utilities for handling `*.hbs` files as abstract syntax tree_
 
 ## What is it?
 
-`@codemod-utils/ast-template` provides methods from [`ember-template-recast`](https://github.com/ember-template-lint/ember-template-recast) to help you parse and transform `*.hbs` files.
+`@codemod-utils/ast-template` provides methods from [`@glimmer/syntax`](https://github.com/emberjs/ember.js/tree/main/packages/%40glimmer/syntax) to help you parse and transform `*.hbs` files.
 
 ::: code-group
 
@@ -34,8 +34,8 @@ An object that provides `builders`, `print`, and `traverse`.
 
 In a `traverse` call, you can specify how to visit the nodes of interest ("visit methods") and how to modify them ("builders").
 
-- [Builders](https://github.com/glimmerjs/glimmer-vm/blob/v0.95.0-%40glimmer/syntax/packages/%40glimmer/syntax/lib/v1/public-builders.ts#L490-L528)
-- [Visit methods](https://github.com/glimmerjs/glimmer-vm/blob/v0.95.0-%40glimmer/syntax/packages/%40glimmer/syntax/lib/v1/visitor-keys.ts#L5-L30)
+- [Builders](https://github.com/emberjs/ember.js/blob/v0.95.0-%40glimmer/syntax/packages/%40glimmer/syntax/lib/v1/public-builders.ts#L490-L528)
+- [Visit methods](https://github.com/emberjs/ember.js/blob/v0.95.0-%40glimmer/syntax/packages/%40glimmer/syntax/lib/v1/visitor-keys.ts#L5-L30)
 
 ::: code-group
 
@@ -76,7 +76,7 @@ function transform(file: string, data: Data): string {
 
 ## How to test your code
 
-Currently, `ember-template-recast` lacks documentation and tutorials. This is unfortunate, given the large amount of builders and visit methods that it provides to help you transform code.
+Currently, `@glimmer/syntax` lacks documentation and tutorials. This is unfortunate, given the large amount of builders and visit methods that it provides to help you transform code.
 
 I recommend using [AST Explorer](https://astexplorer.net/) to test a small piece of code and familiarize with the API. The error messages from TypeScript, which you can find in your browser's console, can sometimes help.
 
@@ -88,8 +88,8 @@ If you intend to publish your codemod, I recommend using [`@codemod-utils/tests`
 In the top navigation menu, select these options to create a 4-tab window:
 
 - Language: `Handlebars`
-- Parser: `ember-template-recast`
-- Transform: `ember-template-recast`
+- Parser: `ember-template-recast` (or `glimmer`)
+- Transform: `ember-template-recast` (or `glimmer`)
 
 The upper-left tab allows you to provide one or more examples of code. In the bottom-left tab, write the code that will transform the examples. You will see the results in the bottom-right tab.
 
@@ -164,7 +164,7 @@ function transform(file: string, data: Data): string {
 
 In theory, every visit method provides you the correct type with `node`.
 
-If a type error occurs when accessing a property in `node`, you likely didn't make an early exit correctly. If the error occurs because `ember-template-recast` didn't provide enough information, then use `@ts-expect-error` to ignore the error for now.
+If a type error occurs when accessing a property in `node`, you likely didn't make an early exit correctly. If the error occurs because `@glimmer/syntax` didn't provide enough information, then use `@ts-expect-error` to ignore the error for now.
 
 If you need to refer to a specific type, you may use TypeScript's `typeof` operator and `Parameters` and `ReturnType` utilities to reach it.
 

--- a/docs/src/docs/tutorials/main-tutorial/05-update-acceptance-tests-part-2.md
+++ b/docs/src/docs/tutorials/main-tutorial/05-update-acceptance-tests-part-2.md
@@ -20,7 +20,7 @@ Goals:
 
 ## Hello, AST!
 
-Libraries like [`recast`](https://github.com/benjamn/recast) and [`ember-template-recast`](https://github.com/ember-template-lint/ember-template-recast) help us convert JS/TS and HBS files to an **AST (abstract syntax tree)**. `codemod-utils` wraps these libraries to provide you an interface that is standardized:
+Libraries like [`recast`](https://github.com/benjamn/recast) and [`@glimmer/syntax`](https://github.com/emberjs/ember.js/tree/main/packages/%40glimmer/syntax) help us convert JS/TS and HBS files to an **AST (abstract syntax tree)**. `codemod-utils` wraps these libraries to provide you an interface that is standardized:
 
 - `AST.traverse` (traverse the tree)
 - `AST.builders` (build a new tree)
@@ -138,7 +138,7 @@ const ast = traverse(file, {
 });
 ```
 
-Currently, `ember-template-recast` and `recast` lack documentation and tutorials. This is unfortunate, given the large amount of **builders** and **visit methods** that they provide to help you transform code.
+Currently, `recast` and `@glimmer/syntax` lack documentation and tutorials. This is unfortunate, given the large amount of **builders** and **visit methods** that they provide to help you transform code.
 
 We will use [AST Explorer](https://astexplorer.net) to test a small piece of code and familiarize with the API. The error messages from TypeScript, which you can find in your browser's console, can sometimes help.
 

--- a/docs/src/docs/tutorials/update-template-tags/00-introduction.md
+++ b/docs/src/docs/tutorials/update-template-tags/00-introduction.md
@@ -2,6 +2,6 @@
 
 `<template>` tag allows Ember developers to write a template (traditionally, an `*.hbs` file) and JavaScript code (`*.{js,ts}`) in the same file. The new format has the file extension of `.gjs` or `.gts`.
 
-This creates interesting problems for codemods because they need to parse and update new file types. By definition, `ember-template-recast` (meant for `*.hbs` files) and `recast` (for `*.{js,ts}`) aren't enough.
+This creates interesting problems for codemods because they need to parse and update new file types. By definition, `@glimmer/syntax` (meant for `*.hbs` files) and `recast` (for `*.{js,ts}`) aren't enough.
 
 [`@codemod-utils/ast-template-tag`](../../packages/codemod-utils-ast-template-tag) helps you _reuse_ methods that update `*.hbs` or `*.{js,ts}` files. To see how, we'll recreate a feature from [`ember-test-selectors`](https://github.com/mainmatter/ember-test-selectors): Remove all test selectors (attributes whose name starts with `data-test`) from templates.

--- a/packages/ast/template/README.md
+++ b/packages/ast/template/README.md
@@ -7,7 +7,7 @@ _Utilities for handling `*.hbs` files as abstract syntax tree_
 
 ## What is it?
 
-`@codemod-utils/ast-template` provides methods from [`ember-template-recast`](https://github.com/ember-template-lint/ember-template-recast) to help you parse and transform `*.hbs` files.
+`@codemod-utils/ast-template` provides methods from [`@glimmer/syntax`](https://github.com/emberjs/ember.js/tree/main/packages/%40glimmer/syntax) to help you parse and transform `*.hbs` files.
 
 ```ts
 import { AST } from '@codemod-utils/ast-template';


### PR DESCRIPTION
## Background

Follows up on #310.
