### PR TITLE
Simplified traverse call

### DIFF
--- a/.changeset/perky-hairs-carry.md
+++ b/.changeset/perky-hairs-carry.md
@@ -1,0 +1,6 @@
+---
+"@codemod-utils/ast-template-tag": minor
+"docs-app-for-codemod-utils": minor
+---
+
+Addressed breaking changes in `@codemod-utils/ast-template@v4`

--- a/.changeset/silver-loops-read.md
+++ b/.changeset/silver-loops-read.md
@@ -1,0 +1,6 @@
+---
+"@codemod-utils/ast-template": major
+"@codemod-utils/ast-javascript": patch
+---
+
+Simplified traverse call

--- a/docs/src/docs/packages/codemod-utils-ast-javascript.md
+++ b/docs/src/docs/packages/codemod-utils-ast-javascript.md
@@ -13,9 +13,7 @@ _Utilities for handling `*.{js,ts}` files as abstract syntax tree_
 import { AST } from '@codemod-utils/ast-javascript';
 
 function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     /* Use AST.builders to transform the tree */
   });
 
@@ -39,7 +37,7 @@ In a `traverse` call, you can specify how to visit the nodes of interest ("visit
 
 ::: code-group
 
-```ts [Example]{9,20,27}
+```ts [Example]{9,18,25}
 import { AST } from '@codemod-utils/ast-javascript';
 
 type Data = {
@@ -48,9 +46,7 @@ type Data = {
 };
 
 function transform(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitCallExpression(path) {
       this.traverse(path);
 
@@ -127,7 +123,7 @@ export default function transformer(code, { recast, parsers }) {
 }
 ```
 
-```ts [Example (Your file)]{12-23}
+```ts [Example (Your file)]{10-21}
 import { AST } from '@codemod-utils/ast-javascript';
 
 type Data = {
@@ -136,9 +132,7 @@ type Data = {
 };
 
 function transform(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitCallExpression(path) {
       this.traverse(path);
 

--- a/docs/src/docs/packages/codemod-utils-ast-template.md
+++ b/docs/src/docs/packages/codemod-utils-ast-template.md
@@ -13,9 +13,7 @@ _Utilities for handling `*.hbs` files as abstract syntax tree_
 import { AST } from '@codemod-utils/ast-template';
 
 function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     /* Use AST.builders to transform the tree */
   });
 
@@ -39,7 +37,7 @@ In a `traverse` call, you can specify how to visit the nodes of interest ("visit
 
 ::: code-group
 
-```ts [Example]{9,23,28}
+```ts [Example]{9,21,26}
 import { AST } from '@codemod-utils/ast-template';
 
 type Data = {
@@ -48,9 +46,7 @@ type Data = {
 };
 
 function transform(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     ElementNode(node) {
       if (node.tag !== 'MyComponent') {
         return;
@@ -126,7 +122,7 @@ module.exports = function (env) {
 };
 ```
 
-```ts [Example (Your file)]{12-24}
+```ts [Example (Your file)]{10-22}
 import { AST } from '@codemod-utils/ast-template';
 
 type Data = {
@@ -135,9 +131,7 @@ type Data = {
 };
 
 function transform(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     ElementNode(node) {
       if (node.tag !== 'MyComponent') {
         return;

--- a/docs/src/docs/tutorials/main-tutorial/05-update-acceptance-tests-part-2.md
+++ b/docs/src/docs/tutorials/main-tutorial/05-update-acceptance-tests-part-2.md
@@ -32,9 +32,7 @@ Libraries like [`recast`](https://github.com/benjamn/recast) and [`@glimmer/synt
 import { AST } from '@codemod-utils/ast-javascript';
 
 function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     /* Use AST.builders to transform the tree */
   });
 
@@ -46,9 +44,7 @@ function transform(file: string): string {
 import { AST } from '@codemod-utils/ast-template';
 
 function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     /* Use AST.builders to transform the tree */
   });
 
@@ -78,9 +74,7 @@ import { findFiles } from '@codemod-utils/files';
 import type { Options } from '../types/index.js';
 
 function renameModule(file: string): string {
-+   const traverse = AST.traverse();
-+ 
-+   const ast = traverse(file, {
++   const ast = AST.traverse(file, {
 +     // ...
 +   });
 + 
@@ -118,7 +112,7 @@ Since `renameModule` is an identity, the `test` script should continue to pass.
 Next, we want to specify how to update the tree (how to rename the test module).
 
 ```ts
-const ast = traverse(file, {
+const ast = AST.traverse(file, {
   // ...
 });
 ```
@@ -398,9 +392,7 @@ import type { Options } from '../types/index.js';
 +
 - function renameModule(file: string): string {
 + function renameModule(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
 -     // ...
 +     visitCallExpression(path) {
 +       if (

--- a/docs/src/docs/tutorials/main-tutorial/06-update-integration-tests.md
+++ b/docs/src/docs/tutorials/main-tutorial/06-update-integration-tests.md
@@ -121,9 +121,7 @@ function getModuleName(filePath: string): string {
 }
 
 function renameModule(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitCallExpression(path) {
       if (
         path.node.callee.type !== 'Identifier' ||
@@ -198,9 +196,7 @@ function getModuleName(filePath: string): string {
 }
 
 function renameModule(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitCallExpression(path) {
       if (
         path.node.callee.type !== 'Identifier' ||

--- a/docs/src/docs/tutorials/main-tutorial/07-update-unit-tests.md
+++ b/docs/src/docs/tutorials/main-tutorial/07-update-unit-tests.md
@@ -100,9 +100,7 @@ function getModuleName(filePath: string): string {
 }
 
 function renameModule(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitCallExpression(path) {
       if (
         path.node.callee.type !== 'Identifier' ||

--- a/docs/src/docs/tutorials/main-tutorial/08-refactor-code-part-1.md
+++ b/docs/src/docs/tutorials/main-tutorial/08-refactor-code-part-1.md
@@ -255,9 +255,7 @@ type Data = {
 };
 
 export function renameModule(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitCallExpression(path) {
       if (
         path.node.callee.type !== 'Identifier' ||

--- a/docs/src/docs/tutorials/update-template-tags/02-tackle-hbs.md
+++ b/docs/src/docs/tutorials/update-template-tags/02-tackle-hbs.md
@@ -33,9 +33,7 @@ First, update `removeDataTestAttributes` so that it uses [`@codemod-utils/ast-te
 
 function removeDataTestAttributes(file: string): string {
 -   return file;
-+   const traverse = AST.traverse();
-+
-+   const ast = traverse(file, {
++   const ast = AST.traverse(file, {
 +     /* Use AST.builders to transform the tree */
 +   });
 +
@@ -57,9 +55,7 @@ To find the correct visit method, recall that we want to remove attributes if th
 import { AST } from '@codemod-utils/ast-template';
 
 function removeDataTestAttributes(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
 -     /* Use AST.builders to transform the tree */
 +     AttrNode(node) {
 +       if (!node.name.startsWith('data-test')) {

--- a/packages/ast/javascript/README.md
+++ b/packages/ast/javascript/README.md
@@ -13,9 +13,7 @@ _Utilities for handling `*.{js,ts}` files as abstract syntax tree_
 import { AST } from '@codemod-utils/ast-javascript';
 
 function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     /* Use AST.builders to transform the tree */
   });
 

--- a/packages/ast/javascript/src/-private/recast.ts
+++ b/packages/ast/javascript/src/-private/recast.ts
@@ -56,21 +56,19 @@ export function print(ast: types.ASTNode): string {
   return code;
 }
 
-export function traverse() {
-  return function (
-    file: string,
-    visitMethods: types.Visitor = {},
-  ): types.ASTNode {
-    const ast = parse(file, {
-      parser: {
-        parse(file: string) {
-          return babelParser(file, tsOptions);
-        },
+export function traverse(
+  file: string,
+  visitMethods: types.Visitor = {},
+): types.ASTNode {
+  const ast = parse(file, {
+    parser: {
+      parse(file: string) {
+        return babelParser(file, tsOptions);
       },
-    }) as types.ASTNode;
+    },
+  }) as types.ASTNode;
 
-    visit(ast, visitMethods);
+  visit(ast, visitMethods);
 
-    return ast;
-  };
+  return ast;
 }

--- a/packages/ast/javascript/src/index.ts
+++ b/packages/ast/javascript/src/index.ts
@@ -18,9 +18,7 @@ type AST = {
  * import { AST } from '@codemod-utils/ast-javascript';
  *
  * function transform(file: string): string {
- *   const traverse = AST.traverse();
- *
- *   const ast = traverse(file, {
+ *   const ast = AST.traverse(file, {
  *     // Use AST.builders to transform the tree
  *   });
  *

--- a/packages/ast/javascript/tests/helpers/index.ts
+++ b/packages/ast/javascript/tests/helpers/index.ts
@@ -1,9 +1,7 @@
 import { AST } from '../../src/index.js';
 
 export function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitClassDeclaration(path) {
       const { body } = path.node.body;
 
@@ -24,9 +22,7 @@ export function transform(file: string): string {
 }
 
 export function traverse(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file);
+  const ast = AST.traverse(file);
 
   return AST.print(ast);
 }

--- a/packages/ast/template-tag/src/-private/to-ecma.ts
+++ b/packages/ast/template-tag/src/-private/to-ecma.ts
@@ -34,11 +34,10 @@ function sortMarkers(a: Marker, b: Marker): number {
 
 export function findMarkers(file: string): Marker[] {
   const { code } = preprocessor.process(file);
-  const traverse = AST.traverse();
 
   const markers: Marker[] = [];
 
-  traverse(code, {
+  AST.traverse(code, {
     visitCallExpression(path) {
       if (path.node.type !== 'CallExpression') {
         this.traverse(path);

--- a/packages/ast/template-tag/src/-private/to-template-tag.ts
+++ b/packages/ast/template-tag/src/-private/to-template-tag.ts
@@ -7,9 +7,7 @@ export function removeMarkers(file: string): string {
     return file;
   }
 
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitCallExpression(path) {
       if (path.node.type !== 'CallExpression') {
         this.traverse(path);

--- a/packages/ast/template-tag/tests/helpers/update-javascript.ts
+++ b/packages/ast/template-tag/tests/helpers/update-javascript.ts
@@ -9,9 +9,7 @@ export const data: Data = {
 };
 
 export function renameGetters(file: string, data: Data): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     visitClassMethod(path) {
       if (path.node.kind !== 'get' || path.node.key.type !== 'Identifier') {
         return false;

--- a/packages/ast/template-tag/tests/helpers/update-templates.ts
+++ b/packages/ast/template-tag/tests/helpers/update-templates.ts
@@ -1,9 +1,7 @@
 import { AST } from '@codemod-utils/ast-template';
 
 export function removeClassAttribute(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     // @ts-expect-error: Incorrect type
     AttrNode(node) {
       if (node.name !== 'class') {

--- a/packages/ast/template/README.md
+++ b/packages/ast/template/README.md
@@ -13,9 +13,7 @@ _Utilities for handling `*.hbs` files as abstract syntax tree_
 import { AST } from '@codemod-utils/ast-template';
 
 function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     /* Use AST.builders to transform the tree */
   });
 

--- a/packages/ast/template/src/-private/glimmer-syntax.ts
+++ b/packages/ast/template/src/-private/glimmer-syntax.ts
@@ -28,14 +28,15 @@ export function print(ast: AST.Node): string {
   });
 }
 
-export function traverse() {
-  return function (file: string, visitMethods: NodeVisitor = {}): AST.Template {
-    const { ast } = new Parser(file, NODE_INFO);
+export function traverse(
+  file: string,
+  visitMethods: NodeVisitor = {},
+): AST.Template {
+  const { ast } = new Parser(file, NODE_INFO);
 
-    upstreamTraverse(ast, visitMethods);
+  upstreamTraverse(ast, visitMethods);
 
-    return ast;
-  };
+  return ast;
 }
 
 export { builders };

--- a/packages/ast/template/src/index.ts
+++ b/packages/ast/template/src/index.ts
@@ -18,9 +18,7 @@ type AST = {
  * import { AST } from '@codemod-utils/ast-template';
  *
  * function transform(file: string): string {
- *   const traverse = AST.traverse();
- *
- *   const ast = traverse(file, {
+ *   const ast = AST.traverse(file, {
  *     // Use AST.builders to transform the tree
  *   });
  *

--- a/packages/ast/template/tests/-private/glimmer-syntax/traverse.test.ts
+++ b/packages/ast/template/tests/-private/glimmer-syntax/traverse.test.ts
@@ -13,7 +13,7 @@ test('-private | glimmer-syntax | traverse > can remove during traversal by retu
     `{{ other-stuff }}`,
   ]);
 
-  const ast = traverse()(template, {
+  const ast = traverse(template, {
     ElementNode() {
       return null;
     },
@@ -28,7 +28,7 @@ test('-private | glimmer-syntax | traverse > can replace with many items during 
     `{{other-stuff}}`,
   ]);
 
-  const ast = traverse()(template, {
+  const ast = traverse(template, {
     ElementNode() {
       return [builders.text('hello '), builders.text('world')];
     },
@@ -51,7 +51,7 @@ test('-private | glimmer-syntax | traverse > issue can handle angle brackets in 
     `</Select>`,
   ]);
 
-  const ast = traverse()(template, {
+  const ast = traverse(template, {
     ElementNode(node) {
       node.tag = `${node.tag}`;
     },
@@ -63,7 +63,7 @@ test('-private | glimmer-syntax | traverse > issue can handle angle brackets in 
 test('-private | glimmer-syntax | traverse > MustacheStatements retain whitespace when multiline replacements occur', function () {
   const template = normalizeFile([`<p></p>`, `{{ other-stuff }}`]);
 
-  const ast = traverse()(template, {
+  const ast = traverse(template, {
     ElementNode() {
       return [builders.text('x'), builders.text('y')];
     },

--- a/packages/ast/template/tests/helpers/index.ts
+++ b/packages/ast/template/tests/helpers/index.ts
@@ -1,9 +1,7 @@
 import { AST } from '../../src/index.js';
 
 export function transform(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file, {
+  const ast = AST.traverse(file, {
     AttrNode(node) {
       if (node.name !== 'local-class') {
         return;
@@ -25,9 +23,7 @@ export function transform(file: string): string {
 }
 
 export function traverse(file: string): string {
-  const traverse = AST.traverse();
-
-  const ast = traverse(file);
+  const ast = AST.traverse(file);
 
   return AST.print(ast);
 }


### PR DESCRIPTION
## Background

Continuation of #319.

Now that `@codemod-utils/ast-javascript` allows 0 arguments for its `AST.traverse`, the intermediate invocation for traverse is unnecessary for both `@codemod-utils/ast-javascript` and `@codemod-utils/ast-template`.

By removing this intermediate step, end-developers will be able to more easily traverse files.


## How to migrate

`AST.traverse` now accepts 2 arguments: the file to traverse and the visit method object.

```diff
import { AST } from '@codemod-utils/ast-javascript';

function transform(file: string): string {
-   const traverse = AST.traverse();
-
-   const ast = traverse(file, {
+   const ast = AST.traverse(file, {
    // ...
  });

  return AST.print(ast);
}
```

```diff
import { AST } from '@codemod-utils/ast-template';

function transform(file: string): string {
-   const traverse = AST.traverse();
-
-   const ast = traverse(file, {
+   const ast = AST.traverse(file, {
    // ...
  });

  return AST.print(ast);
}
```
