### PR TITLE
Enabled Google Analytics

### DIFF
--- a/.changeset/plain-beds-cover.md
+++ b/.changeset/plain-beds-cover.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-codemod-utils": minor
+---
+
+Enabled Google Analytics

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,6 +6,23 @@ export default defineConfig({
   base: '/',
   cleanUrls: true,
   description: 'Framework for writing codemods',
+  head: [
+    [
+      'script',
+      {
+        async: '',
+        src: 'https://www.googletagmanager.com/gtag/js?id=G-Z21PQ9B294',
+      },
+    ],
+    [
+      'script',
+      {},
+      `window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-Z21PQ9B294');`,
+    ],
+  ],
   lastUpdated: true,
   markdown: {
     anchor: {


### PR DESCRIPTION
## Background

I enabled Analytics partly to verify ownership for submitting the sitemap.


## References

- https://vitepress.dev/reference/site-config#example-using-google-analytics
