### PR TITLE
Added @sondr3/minitest to dependencies

### DIFF
--- a/.changeset/sweet-experts-agree.md
+++ b/.changeset/sweet-experts-agree.md
@@ -1,0 +1,5 @@
+---
+"@codemod-utils/tests": minor
+---
+
+Added @sondr3/minitest to dependencies

--- a/packages/ast/javascript/package.json
+++ b/packages/ast/javascript/package.json
@@ -54,7 +54,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/packages/ast/template-tag/package.json
+++ b/packages/ast/template-tag/package.json
@@ -55,7 +55,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/packages/ast/template/package.json
+++ b/packages/ast/template/package.json
@@ -53,7 +53,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/packages/blueprints/package.json
+++ b/packages/blueprints/package.json
@@ -53,7 +53,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/lodash": "^4.17.25",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "@types/yargs": "^17.0.35",
     "concurrently": "^10.0.4",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -50,7 +50,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -53,7 +53,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/packages/package-json/package.json
+++ b/packages/package-json/package.json
@@ -53,7 +53,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/packages/tests/bin/mt.ts
+++ b/packages/tests/bin/mt.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import { run } from '@sondr3/minitest/dist/runner.js';
+
+process.env['NODE_ENV'] = 'test';
+
+void run(process.argv);

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -58,7 +58,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -16,13 +16,16 @@
   "author": "Isaac J. Lee",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
+    ".": "./dist/src/index.js",
     "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
+      "types": "./dist/src/*.d.ts",
+      "default": "./dist/src/*.js"
     }
   },
   "main": "dist/index.js",
+  "bin": {
+    "mt": "dist/bin/mt.js"
+  },
   "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
@@ -43,9 +46,11 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
+    "prepack": "pnpm build",
     "test": "sh build.sh --test && echo \"@codemod-utils/tests does not have tests.\""
   },
   "dependencies": {
+    "@sondr3/minitest": "^0.1.2",
     "fixturify": "^3.0.0",
     "glob": "^13.0.6"
   },
@@ -59,14 +64,6 @@
     "eslint": "^10.8.1",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3"
-  },
-  "peerDependencies": {
-    "@sondr3/minitest": "^0.1.2"
-  },
-  "peerDependenciesMeta": {
-    "@sondr3/minitest": {
-      "optional": false
-    }
   },
   "engines": {
     "node": "22.* || >= 24"

--- a/packages/tests/tsconfig.build.json
+++ b/packages/tests/tsconfig.build.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "outDir": "dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "types": ["@types/node"]
   },
-  "include": ["src"]
+  "include": ["bin", "src"]
 }

--- a/packages/tests/tsconfig.json
+++ b/packages/tests/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "outDir": "dist-for-testing",
-    "rootDir": "./src",
+    "rootDir": ".",
     "types": ["@types/node"]
   },
-  "include": ["src"]
+  "include": ["bin", "src"]
 }

--- a/packages/threads/package.json
+++ b/packages/threads/package.json
@@ -50,7 +50,6 @@
     "@shared-configs/eslint-config-node": "workspace:*",
     "@shared-configs/prettier": "workspace:*",
     "@shared-configs/typescript": "workspace:*",
-    "@sondr3/minitest": "^0.1.2",
     "@types/node": "^22.20.1",
     "concurrently": "^10.0.4",
     "eslint": "^10.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,9 +145,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -182,9 +179,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -225,9 +219,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -262,9 +253,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/lodash':
         specifier: ^4.17.25
         version: 4.17.25
@@ -311,9 +299,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -347,9 +332,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -384,9 +366,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -421,9 +400,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -442,6 +418,9 @@ importers:
 
   packages/tests:
     dependencies:
+      '@sondr3/minitest':
+        specifier: ^0.1.2
+        version: 0.1.2
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
@@ -458,9 +437,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
@@ -491,9 +467,6 @@ importers:
       '@shared-configs/typescript':
         specifier: workspace:*
         version: link:../../configs/typescript
-      '@sondr3/minitest':
-        specifier: ^0.1.2
-        version: 0.1.2
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1


### PR DESCRIPTION
## Background

Tests whether `@codemod-utils/tests` can ship [`@sondr3/minitest`](https://github.com/sondr3/minitest) as its dependency, so that `@codemod-utils/cli` and end-developers don't need to include it themselves.

The last time I had tried this (with an older version of `@sondr3/minitest`), something didn't work (likely due to the `test` script requiring the name `mt`). I want to investigate the cause by releasing a minor version with the extra dependency.
